### PR TITLE
Manage to create irbrc symlink with home-manager

### DIFF
--- a/.config/home-manager/home.nix
+++ b/.config/home-manager/home.nix
@@ -91,6 +91,8 @@
 
   programs.zoxide.enable = true;
 
+  xdg.configFile."irb/irbrc".source = ../irb/irbrc;
+
   # TODO: Consider to manage nix.conf with home-manager. However it includes`trusted-public-keys`
   # nix.package = pkgs.nix;
   # nix.settings = {


### PR DESCRIPTION
- irbrc はそもそもここで管理しないか、 https://github.com/kachick/irb-power_assert/blob/98ad68b4c391bb30adee1ba119cb6c6ed5bd0bfc/examples/.irbrc を home-manager の github から fetch するやつで管理したい気はする。しかしそれは別のタスクとしてやる
- irbrc の管理みたいな manager はあった気がするけど、そういうの使うと syntax highlight とか効かないし、file manager で十分な気はする。で、こういった symlink 管理も任せられる以上 パスワードマネージャーで管理みたいな話を気にしなければ chezmoi は不要な感
  -  Closes #182
  -  Closes #171 
- この路線を進めていけば https://github.com/kachick/dotfiles/issues/172 は close で良い気がする。これはやりきってから close のが良さそう