### PR TITLE
Run fmt parallel

### DIFF
--- a/cmd/fmt/main.go
+++ b/cmd/fmt/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
 )
@@ -25,10 +26,13 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	cmds := []struct {
+	type command struct {
 		path string
 		args []string
-	}{
+	}
+
+	// Do not cover the same files in another formatter for parallel processing
+	cmds := []command{
 		{"dprint", []string{"fmt"}},
 		{"shfmt", append([]string{"--language-dialect", "bash", "--write"}, bashPaths...)},
 		{"nixpkgs-fmt", nixPaths},
@@ -36,11 +40,17 @@ func main() {
 		{"go", []string{"fmt", "./..."}},
 	}
 
+	wg := &sync.WaitGroup{}
 	for _, cmd := range cmds {
-		output, err := exec.Command(cmd.path, cmd.args...).Output()
-		log.Printf("%s %s\n%s\n", cmd.path, strings.Join(cmd.args, " "), output)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		wg.Add(1)
+		go func(cmd command) {
+			defer wg.Done()
+			output, err := exec.Command(cmd.path, cmd.args...).Output()
+			log.Printf("%s %s\n%s\n", cmd.path, strings.Join(cmd.args, " "), output)
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}(cmd)
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
Same as #208

Before
---

```console
❯ hyperfine dist/fmt
Benchmark 1: dist/fmt
  Time (mean ± σ):     196.8 ms ±   4.3 ms    [User: 93.4 ms, System: 136.8 ms]
  Range (min … max):   191.2 ms … 206.0 ms    14 runs
```

After
---

```console
❯ hyperfine dist/fmt
Benchmark 1: dist/fmt
  Time (mean ± σ):      98.8 ms ±   4.4 ms    [User: 114.5 ms, System: 149.6 ms]
  Range (min … max):    87.9 ms … 106.9 ms    28 runs
```