### PR TITLE
Move nix in darwin workaround in env phase

### DIFF
--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -6,12 +6,16 @@ lib.mkMerge [
     xdg.configFile."iterm2/com.googlecode.iterm2.plist".source = ../home/.config/iterm2/com.googlecode.iterm2.plist;
 
     # Do not use `programs.zsh.dotDir`, it does not refer xdg module
-    xdg.configFile."zsh/.zshrc.darwin".text = ''
+
+    xdg.configFile."zsh/.zshenv.darwin".text = ''
       # See https://github.com/kachick/dotfiles/issues/159 and https://github.com/NixOS/nix/issues/3616
+      # nix loaded programs may be used in zshrc and non interactive mode, so this workaround should be included in zshenv
       if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
         . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
       fi
+    '';
 
+    xdg.configFile."zsh/.zshrc.darwin".text = ''
       source ${pkgs.iterm2 + "/Applications/iTerm2.app/Contents/Resources/iterm2_shell_integration.zsh"}
     '';
 

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -84,6 +84,12 @@
 
     # home-manager path will set in `programs.home-manager.enable = true`;
     envExtra = ''
+      case ''${OSTYPE} in
+      darwin*)
+        source '${config.xdg.configHome}/zsh/.zshenv.darwin'
+        ;;
+      esac
+
       # https://gist.github.com/ctechols/ca1035271ad134841284?permalink_comment_id=3401477#gistcomment-3401477
       skip_global_compinit=1
 


### PR DESCRIPTION
This PR fixes zellij error in macOS since https://github.com/kachick/dotfiles/pull/283

```plaintext
Last login: Wed Aug 23 14:06:56 on ttys000
/Users/kachick/.config/zsh/.zshrc:72: command not found: zellij
```