### PR TITLE
Add global commit-msg hook to prevent typos in git commit messages

### DIFF
--- a/config/git/hooks/commit-msg.bash
+++ b/config/git/hooks/commit-msg.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+typos "$1"

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -22,6 +22,10 @@
       pp = "log --pretty=format:'%Cgreen%cd %Cblue%h %Creset%s' --date=short --decorate --graph --tags HEAD";
     };
 
+    hooks = {
+      commit-msg = ../config/git/hooks/commit-msg.bash;
+    };
+
     extraConfig = {
       user = {
         # - Visibility

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -22,6 +22,8 @@
       pp = "log --pretty=format:'%Cgreen%cd %Cblue%h %Creset%s' --date=short --decorate --graph --tags HEAD";
     };
 
+    # - They will be overridden by local hooks, currently I do nothing to merge global and local hooks
+    # - Remember to add executable permission for hooks files
     hooks = {
       commit-msg = ../config/git/hooks/commit-msg.bash;
     };


### PR DESCRIPTION
Resolves #323
Resolves https://github.com/kachick/times_kachick/issues/238

Tested with following commit in another repository, because this repository has local hooks path...

```
git commit -m 'This commit message includes typo "minimumn"' --allow-empty
```
