### PR TITLE
Run CI against macos-14 M1 runner

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-14 # M1 - https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+          - macos-13 # Intel(Maybe)
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13
+          - macos-14 # M1 - https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+          - macos-13 # Intel(Maybe)
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-14 # M1 - https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+          - macos-13 # Intel(Maybe)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Resolves #319 

https://github.com/actions/runner-images/issues/7508#issuecomment-1917416413
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/