### PR TITLE
Fix conflicted and broken `AddKeysToAgen` with updated home-manager

### DIFF
--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -46,6 +46,8 @@ in
     controlMaster = "auto";
     controlPersist = "10m";
 
+    addKeysToAgent = "yes";
+
     # Enable custom or temporary config without `home-manager switch`
     includes = [
       "${sshDir}/config.local"
@@ -54,8 +56,6 @@ in
     # https://www.clear-code.com/blog/2023/4/3/recommended-ssh-config.html
     # https://gitlab.com/clear-code/ssh.d/-/blob/main/global.conf?ref_type=heads
     extraConfig = ''
-      AddKeysToAgent yes
-
       PasswordAuthentication no
 
       # default: "ask" - I'm disabling it for now


### PR DESCRIPTION
No keeping by ssh-agent these days. I think this is the cause.

https://github.com/nix-community/home-manager/pull/3499#issuecomment-18633792381
https://github.com/nix-community/home-manager/issues/4865

```
  16   │ Host *
  17   │   ForwardAgent yes
  18   │   AddKeysToAgent no
...
  27   │
  28   │   AddKeysToAgent yes
```

Update https://github.com/kachick/dotfiles/pull/263 and https://github.com/kachick/dotfiles/pull/264