### PR TITLE
Drop installing Authy in windows

### DIFF
--- a/config/windows/winget/winget-pkgs-basic.json
+++ b/config/windows/winget/winget-pkgs-basic.json
@@ -14,9 +14,6 @@
           "PackageIdentifier": "Microsoft.EdgeWebView2Runtime"
         },
         {
-          "PackageIdentifier": "Twilio.Authy"
-        },
-        {
           "PackageIdentifier": "Kensington.KensingtonWorks"
         },
         {


### PR DESCRIPTION
Resolves #399 

This PR just drops the dependency

---

💭 

I have tried several tools.

- Bitwarden way is much simple and easy. But all🥚in same 🧃 
- Keeping another tool, following are candidates. But the keeping encrypted backup with cloud drive is actually safe than Bitwarden? 🤔 And no desktop app exists. 
  - https://github.com/twofas/2fas-android 
  - https://github.com/beemdevelopment/Aegis
  - https://github.com/raivo-otp/ios-application