### PR TITLE
Update go to 1.22

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
               gitleaks
               cargo-make
               typos
-              go_1_21
+              go_1_22
               goreleaser
 
               # To get sha256 around pkgs.fetchFromGitHub in CLI

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kachick/dotfiles
 
-go 1.22
-
-toolchain go1.22rc2
+go 1.22.0
 
 require (
 	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kachick/dotfiles
 
-go 1.21
+go 1.22
 
-toolchain go1.21.0
+toolchain go1.22rc2
 
 require (
 	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b


### PR DESCRIPTION
```
> go version
go version go1.22rc2 linux/amd64
```

https://github.com/kachick/dotfiles/blob/ec72c10933d470e45bf5c54fbda58f0cc7b7fcfa/flake.lock#L48C17-L48C57 => https://github.com/NixOS/nixpkgs/tree/f8e2ebd66d097614d51a56a755450d4ae1632df1 is still rc2

So #397 is a blocker


- https://github.com/golang/go/issues/62278#issuecomment-1933790368 maybe needed in later steps