### PR TITLE
Enable gitleaks global

### DIFF
--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -65,6 +65,7 @@
     gitleaks
     deno
     actionlint
+    gitleaks
     ruby_3_3
 
     # Do not specify vim and the plugins at here, it made collisions from home-manager vim module.


### PR DESCRIPTION
Already used in this repo

https://github.com/kachick/dotfiles/blob/3b00345cf2067ac098c1ef8e9e17444ca24d95d0/flake.nix#L35

But enable in global scope

`--no-git` option and the basic behaviors hels me a lot especially for private to public

https://github.com/kachick/times_kachick/issues/258#issuecomment-1956680088

```bash
gitleaks detect --verbose
gitleaks detect --no-git --verbose
```