### PR TITLE
Sort by `-committerdate` for git branch list

### DIFF
--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -84,7 +84,8 @@
 
       branch = {
         # Candidates: https://github.com/git/git/blob/3c2a3fdc388747b9eaf4a4a4f2035c1c9ddb26d0/ref-filter.c#L902-L959
-        sort = "committerdate";
+        # Append `-` prefix if you want to reverse the order: https://gfx.hatenablog.com/entry/2016/06/10/153747
+        sort = "-committerdate";
       };
     };
   };

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -81,6 +81,11 @@
       pull = {
         ff = "only";
       };
+
+      branch = {
+        # Candidates: https://github.com/git/git/blob/3c2a3fdc388747b9eaf4a4a4f2035c1c9ddb26d0/ref-filter.c#L902-L959
+        sort = "committerdate";
+      };
     };
   };
 

--- a/home-manager/homemade.nix
+++ b/home-manager/homemade.nix
@@ -74,6 +74,8 @@
     #   - Prefer git built-in features to filter as possible, handling correct regex is often hard for human
     #   - grep returns false if empty, it does not fit for pipefail use. --no-run-if-empty as xargs does not exists in the grep options
     #   - Always specify --sort to ensure it can be used in comm command. AFAIK, refname is most fit key here.
+    #     Make sure, this result should not be changed even if you changed in global git config with git.nix
+    #     Candidates: https://github.com/git/git/blob/3c2a3fdc388747b9eaf4a4a4f2035c1c9ddb26d0/ref-filter.c#L902-L959
 
     ${lib.getBin pkgs.git}/bin/git branch --sort=refname --list main master trunk develop development |
     ${lib.getBin pkgs.coreutils}/bin/comm --check-order -13 - <(${lib.getBin pkgs.git}/bin/git branch --sort=refname --merged) |


### PR DESCRIPTION
before

```console
> git branch --no-merged
  amdaifea
  commit-with-last-execution-cmds
  dafasedf
  fix-selfup-empty-newver
  iiwi
  nix-flake-check
  poipoi
  prefer-stable-release-23.05
  pwsh-hist
  rebel-for-ms-cop
  release-after-each-push-default
```

after

```console
> git branch --no-merged
  rebel-for-ms-cop
  release-after-each-push-default
  iiwi
  poipoi
  pwsh-hist
  dafasedf
  amdaifea
  commit-with-last-execution-cmds
  prefer-stable-release-23.05
  fix-selfup-empty-newver
  nix-flake-check
```

```console
> git branch --sort=refname --no-merged
  amdaifea
  commit-with-last-execution-cmds
  dafasedf
  fix-selfup-empty-newver
  iiwi
  nix-flake-check
  poipoi
  prefer-stable-release-23.05
  pwsh-hist
  rebel-for-ms-cop
  release-after-each-push-default
```