### PR TITLE
Follow updated zsh module in home-manager

### DIFF
--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -65,10 +65,11 @@
       # Candidates: https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/docs/highlighters.md
       highlighters = [
         "brackets"
-        "patterns"
+        "pattern" # Not pattern"s"!
         "root"
       ];
 
+      # This will work if you enabled "pattern" highlighter
       patterns = {
         # https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/docs/highlighters/pattern.md
         "rm -rf *" = "fg=white,bold,bg=red";

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -62,6 +62,13 @@
         unknown-token = "fg=magenta";
       };
 
+      # Candidates: https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/docs/highlighters.md
+      highlighters = [
+        "brackets"
+        "patterns"
+        "root"
+      ];
+
       patterns = {
         # https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/docs/highlighters/pattern.md
         "rm -rf *" = "fg=white,bold,bg=red";

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -61,9 +61,16 @@
       styles = {
         unknown-token = "fg=magenta";
       };
+
+      patterns = {
+        # https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/docs/highlighters/pattern.md
+        "rm -rf *" = "fg=white,bold,bg=red";
+      };
     };
 
-    enableAutosuggestions = true;
+    autosuggestion = {
+      enable = true;
+    };
 
     # NOTE: enabling without tuning makes much slower zsh as +100~200ms execution time
     #       And the default path is not intended, so you SHOULD update `completionInit`


### PR DESCRIPTION
https://github.com/nix-community/home-manager/pull/5011
https://github.com/nix-community/home-manager/pull/4704

How to know renamed feature before merging the flake.lock updates?
Now I can know in the warning 🤔 