### PR TITLE
Refine `git log` and the Pretty-Print with `fzf` + `bat`

### DIFF
--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -6,6 +6,10 @@
   ...
 }:
 
+# tig
+#
+# tig cannot be used as a standard UNIX filter tools, it prints with ncurses, not to STDOUT
+
 let
   git-log-fzf = pkgs.writeShellApplication {
     name = "git-log-pp-fzf";
@@ -14,7 +18,6 @@ let
       coreutils
       gh
       colorized-logs
-      tig
     ];
     text = ''
       # https://github.com/junegunn/fzf-git.sh/blob/0f1e52079ffd9741eec723f8fd92aa09f376602f/fzf-git.sh#L118C1-L125C2
@@ -28,7 +31,7 @@ let
       }
 
       _fzf_git_fzf --ansi --nth 1,3.. --no-sort --border-label '🪵 Logs' \
-        --preview 'echo {} | cut --delimiter " " --fields 2 --only-delimited | ansi2txt | tig show --stdin' \
+        --preview 'echo {} | cut --delimiter " " --fields 2 --only-delimited | ansi2txt | xargs --no-run-if-empty --max-lines=1 git show' \
         --bind 'enter:become(gh repo view --branch {2} --web)'
     '';
   };

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -128,6 +128,10 @@
         sort = "-committerdate";
       };
 
+      log = {
+        date = "iso-local";
+      };
+
       url = {
         # Why?
         # - ghq default is https, this omit -p option for the ssh push

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -31,7 +31,11 @@ let
       }
 
       _fzf_git_fzf --ansi --nth 1,3.. --no-sort --border-label '🪵 Logs' \
-        --preview 'echo {} | cut --delimiter " " --fields 2 --only-delimited | ansi2txt | xargs --no-run-if-empty --max-lines=1 git show' \
+        --preview 'echo {} | \
+          cut --delimiter " " --fields 2 --only-delimited | \
+          ansi2txt | \
+          xargs --no-run-if-empty --max-lines=1 git show --color=always | \
+          bat --language=gitlog --color=always --style=plain --wrap=character' \
         --bind 'enter:become(gh repo view --branch {2} --web)'
     '';
   };

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -29,7 +29,7 @@
       refresh = "!git switch-default && git pull --prune \"$(git upstream)\" \"$(git current)\"";
       all = "!git refresh && git-delete-merged-branches";
       # Do not add `--graph`, it makes too slow in large repository as NixOS/nixpkgs
-      pp = "log --pretty=format:'%Cgreen%cd %Cblue%h %Creset%s' --date=short --decorate --tags HEAD";
+      pp = "log --format='format:%C(cyan)%ad %C(auto)%h %C(auto)%s %x09 %C(auto)%d' --date=short --color=always";
     };
 
     # TODO: They will be overridden by local hooks, Fixes in #545

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -13,6 +13,8 @@ let
       edge-pkgs.fzf
       coreutils
       gh
+      colorized-logs
+      tig
     ];
     text = ''
       # https://github.com/junegunn/fzf-git.sh/blob/0f1e52079ffd9741eec723f8fd92aa09f376602f/fzf-git.sh#L118C1-L125C2
@@ -26,7 +28,7 @@ let
       }
 
       _fzf_git_fzf --ansi --nth 1,3.. --no-sort --border-label '🪵 Logs' \
-        --preview 'echo {} | cut -d " " -f 2 | xargs --no-run-if-empty --max-lines=1 git show --color=always' \
+        --preview 'echo {} | cut --delimiter " " --fields 2 --only-delimited | ansi2txt | tig show --stdin' \
         --bind 'enter:become(gh repo view --branch {2} --web)'
     '';
   };

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -25,7 +25,7 @@ let
           --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
       }
 
-      _fzf_git_fzf --ansi --nth 3..,.. --no-sort --border-label '🪵 Logs' \
+      _fzf_git_fzf --ansi --nth 1,3.. --no-sort --border-label '🪵 Logs' \
         --preview 'echo {} | cut -d " " -f 2 | xargs --no-run-if-empty --max-lines=1 git show --color=always' \
         --bind 'enter:become(gh repo view --branch {2} --web)'
     '';

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -10,7 +10,7 @@ let
   git-log-fzf = pkgs.writeShellApplication {
     name = "git-log-pp-fzf";
     runtimeInputs = with pkgs; [
-      fzf
+      edge-pkgs.fzf
       coreutils
       gh
     ];
@@ -26,7 +26,7 @@ let
       }
 
       _fzf_git_fzf --ansi --nth 3..,.. --no-sort --border-label '🪵 Logs' \
-        --preview 'echo "{}" | cut -d " " -f 2 | xargs --no-run-if-empty --max-lines=1 git show --color=always' \
+        --preview 'echo {} | cut -d " " -f 2 | xargs --no-run-if-empty --max-lines=1 git show --color=always' \
         --bind 'enter:become(gh repo view --branch {2} --web)'
     '';
   };

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -6,6 +6,31 @@
   ...
 }:
 
+let
+  git-log-fzf = pkgs.writeShellApplication {
+    name = "git-log-pp-fzf";
+    runtimeInputs = with pkgs; [
+      fzf
+      coreutils
+      gh
+    ];
+    text = ''
+      # https://github.com/junegunn/fzf-git.sh/blob/0f1e52079ffd9741eec723f8fd92aa09f376602f/fzf-git.sh#L118C1-L125C2
+      _fzf_git_fzf() {
+        fzf-tmux -p80%,60% -- \
+          --layout=reverse --multi --height=50% --min-height=20 --border \
+          --border-label-pos=2 \
+          --color='header:italic:underline,label:blue' \
+          --preview-window='right,50%,border-left' \
+          --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
+      }
+
+      _fzf_git_fzf --ansi --nth 3..,.. --no-sort --border-label '🪵 Logs' \
+        --preview 'echo "{}" | cut -d " " -f 2 | xargs --no-run-if-empty --max-lines=1 git show --color=always' \
+        --bind 'enter:become(gh repo view --branch {2} --web)'
+    '';
+  };
+in
 {
   home.file."repos/.keep".text = "Put repositories here";
 
@@ -30,6 +55,7 @@
       all = "!git refresh && git-delete-merged-branches";
       # Do not add `--graph`, it makes too slow in large repository as NixOS/nixpkgs
       pp = "log --format='format:%C(cyan)%ad %C(auto)%h %C(auto)%s %x09 %C(auto)%d' --date=short --color=always";
+      lf = "!git pp | ${lib.getExe git-log-fzf}";
     };
 
     # TODO: They will be overridden by local hooks, Fixes in #545

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -63,7 +63,7 @@ in
       refresh = "!git switch-default && git pull --prune \"$(git upstream)\" \"$(git current)\"";
       all = "!git refresh && git-delete-merged-branches";
       # Do not add `--graph`, it makes too slow in large repository as NixOS/nixpkgs
-      pp = "log --format='format:%C(cyan)%ad %C(auto)%h %C(auto)%s %x09 %C(auto)%d' --date=short --color=always";
+      pp = "log --format='format:%C(cyan)%ad %C(auto)%h %C(auto)%s %C(auto)%d' --date=short --color=always";
       lf = "!git pp | ${lib.getExe git-log-fzf}";
     };
 

--- a/home-manager/homemade.nix
+++ b/home-manager/homemade.nix
@@ -6,6 +6,7 @@
 # --nth: Match there
 # --with-nth: Whole display and outputs. None of only outputs: See https://github.com/junegunn/fzf/issues/1323
 # --bind 'enter:become(...)': Replace process, and no execution if not match
+# --ansi: Handle colored input, but remember the output is dirty with the ANSI for another tools. You may need strip them before use.
 
 # - Tiny tools by me, they may be rewritten with another language.
 # - Aliases across multiple shells

--- a/home-manager/homemade.nix
+++ b/home-manager/homemade.nix
@@ -1,5 +1,12 @@
 { pkgs, edge-pkgs, ... }:
 
+# fzf
+#
+# --preview: the placeholder will be quoted by singlequote, so do not add excess double quote as "{}". This will be evaluated the given `` and $()
+# --nth: Match there
+# --with-nth: Whole display and outputs. None of only outputs: See https://github.com/junegunn/fzf/issues/1323
+# --bind 'enter:become(...)': Replace process, and no execution if not match
+
 # - Tiny tools by me, they may be rewritten with another language.
 # - Aliases across multiple shells
 let

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -47,7 +47,6 @@
       edge-pkgs.mise # alt asdf
 
       git
-      tig
       gh
       ghq
 

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -138,6 +138,8 @@
       openssh
 
       iputils # `ping` etc
+
+      wslu # WSL helpers like `wslview`
     ])
     ++ (lib.optionals stdenv.isDarwin [
       # https://github.com/NixOS/nixpkgs/issues/240819


### PR DESCRIPTION
Closes #521
Resolves a part of #499, so closes #499 for now
Update #248

tig and lazygit is slow in large repository like the nixpkgs
gitui is enough speed, but I feel standardizing with fzf is better for now.

