### PR TITLE
Mount Ubuntu volumes to a container on podman-remote which connects to a podman-machine in another WSL2 instance

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -122,7 +122,7 @@ args = [
   '-b',
   'backup',
   '--flake',
-  '.#kachick',
+  '.#${@}',
 ]
 
 [tasks.ci-dev]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 Personal dotfiles that can be placed in the public repository\
 Also known as [盆栽(bonsai)](https://en.wikipedia.org/wiki/Bonsai) 🌳
 
+## For visitors
+
+If you are using the [podman](https://podman.io/), You can test the pre-built [container-image](containers) as follows.
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/kachick/dotfiles/main/containers/sandbox-with-ghcr.bash) latest
+```
+
+For local use, replace `s/PRESONA/user/` in following sections may fit.
+
 ## Installation - Linux(Ubuntu), Darwin
 
 1. Install [Nix](https://nixos.org/) package manager with [DeterminateSystems/nix-installer](https://github.com/DeterminateSystems/nix-installer).
@@ -24,8 +34,7 @@ Also known as [盆栽(bonsai)](https://en.wikipedia.org/wiki/Bonsai) 🌳
    ```bash
    bash
    ```
-1. Install [home-manager](https://github.com/nix-community/home-manager) and dotfiles\
-   For visitors, if you want to test these dotfiles, `s/PRESONA/user/` will fit.
+1. Apply dotfiles for each use
    ```bash
    nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#PERSONA'
    ```
@@ -40,12 +49,6 @@ If you are developing this repository, the simple reactivation is as follows.
 
 ```bash
 makers apply PERSONA
-```
-
-If you are using the [podman](https://podman.io/), You can test the pre-built [container-image](containers) as follows.
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/kachick/dotfiles/main/containers/sandbox-with-ghcr.bash) latest
 ```
 
 Using podmain may require to install some dependencies without Nix

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Also known as [盆栽(bonsai)](https://en.wikipedia.org/wiki/Bonsai) 🌳
    ```bash
    bash
    ```
-1. Install [home-manager](https://github.com/nix-community/home-manager) and dotfiles
+1. Install [home-manager](https://github.com/nix-community/home-manager) and dotfiles\
+   For visitors, if you want to test these dotfiles, `s/PRESONA/user/` will fit.
    ```bash
-   nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#kachick'
+   nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#PERSONA'
    ```
 
 ## Installation - Windows
@@ -38,7 +39,7 @@ Read [the tips](config/windows/README.md) and CI
 If you are developing this repository, the simple reactivation is as follows.
 
 ```bash
-makers apply
+makers apply PERSONA
 ```
 
 If you are using the [podman](https://podman.io/), You can test the pre-built [container-image](containers) as follows.

--- a/cmd/wsl-init/main.go
+++ b/cmd/wsl-init/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Exists for remember https://github.com/kachick/dotfiles/pull/264#discussion_r1289600371
-func mustActivateSystemDOnWSL() {
+func mustActivateSystemdOnWSL() {
 	path := filepath.Join("etc", "wsl.conf")
 
 	const systemdEnablingEntry = `[boot]
@@ -72,5 +72,5 @@ func main() {
 		log.Fatalf("Looks executed on non WSL systems: %s", unameStr)
 	}
 
-	mustActivateSystemDOnWSL()
+	mustActivateSystemdOnWSL()
 }

--- a/config/windows/README.md
+++ b/config/windows/README.md
@@ -282,6 +282,34 @@ You can login with the port number, for example 53061
 ssh user@localhost -p 53061
 ```
 
+## How mount client volume with podman-remote
+
+After SSH setup as above steps
+
+In WSL - Ubuntu
+
+```bash
+rclone config create podman-machine sftp host=localhost port=53061 publickey=~/.ssh/id_ed25519.pub user=user
+# Make sure the connection
+rclone lsd podman-machine:/home/user
+
+mkdir -p for-mount
+rclone mount podman-machine:/home/user/myproject42 ./for-mount &
+
+cp README.md for-mount
+rclone cat podman-machine:/home/user/myproject42/README.md
+```
+
+Unmount
+
+```bash
+# Unmount instead of kill the background job
+# Linux
+fusermount -u /path/to/local/mount
+# OS X
+umount /path/to/local/mount
+```
+
 ## Why aren't these packages in winget list?
 
 - [micro](https://github.com/zyedidia/micro/issues/2339)

--- a/config/windows/README.md
+++ b/config/windows/README.md
@@ -248,6 +248,17 @@ winget install --exact --id RedHat.Podman-Desktop
 
 And create the new podman-machine-default
 
+## How mount project volumes in podman-remote
+
+Track the [official discussion](https://github.com/containers/podman/discussions/13537), but there are no simple solutions for now.\
+This repository provides a mount based solution, mount from another instance as /mnt/wsl/..., then podman-machine also can access there.
+
+1. Ubuntu: Activate the home-manager with `--flake .#wsl`.
+2. Look the [definitions](../../home-manager/wsl.nix), it includes how to mount with systemd.
+3. podman-machine: Make sure podman-machine can read there `ls /mnt/wsl/instances/ubuntu22/home`
+4. Ubuntu: `cdg project_path`
+5. Ubuntu: `podman run -v /mnt/wsl/instances/ubuntu22/"$(pwd)":/workdir -it ghcr.io/ruby/ruby:master-dev-76732b3e7b42d23290cd96cd695b2373172c8a43-jammy`
+
 ## How SSH login to podman-machine from another WSL instance like default Ubuntu?
 
 ### WSL - Ubuntu

--- a/config/windows/README.md
+++ b/config/windows/README.md
@@ -293,21 +293,15 @@ rclone config create podman-machine sftp host=localhost port=53061 publickey=~/.
 # Make sure the connection
 rclone lsd podman-machine:/home/user
 
-mkdir -p for-mount
-rclone mount podman-machine:/home/user/myproject42 ./for-mount &
+z project_path 
+rclone mount --daemon "podman-machine:repos/$(basename "$(pwd)")" .
 
-cp README.md for-mount
-rclone cat podman-machine:/home/user/myproject42/README.md
-```
-
-Unmount
-
-```bash
-# Unmount instead of kill the background job
+# If you want to unmount, use specific command instead of kill the background job
+# 
 # Linux
 fusermount -u /path/to/local/mount
 # OS X
-umount /path/to/local/mount
+# umount /path/to/local/mount
 ```
 
 ## How oneshot sync source code for podman-remote

--- a/config/windows/README.md
+++ b/config/windows/README.md
@@ -310,6 +310,20 @@ fusermount -u /path/to/local/mount
 umount /path/to/local/mount
 ```
 
+## How oneshot sync source code for podman-remote
+
+This is just a note, prefer `rclone mount` for easier
+
+After SSH setup as above steps
+
+In WSL - Ubuntu
+
+```bash
+z project_path
+
+rclone sync --progress . "podman-machine:repos/$(basename "$(pwd)")"
+```
+
 ## Why aren't these packages in winget list?
 
 - [micro](https://github.com/zyedidia/micro/issues/2339)

--- a/config/windows/README.md
+++ b/config/windows/README.md
@@ -248,6 +248,40 @@ winget install --exact --id RedHat.Podman-Desktop
 
 And create the new podman-machine-default
 
+## How SSH login to podman-machine from another WSL instance like default Ubuntu?
+
+### WSL - Ubuntu
+
+Get pubkey
+
+```bash
+cat ~/.ssh/id_ed25519.pub | clip.exe
+```
+
+### WSL - podman-machine
+
+Register the Ubuntu pubkey
+
+```bash
+vi ~/.ssh/authorized_keys
+```
+
+### Host - Windows
+
+Get podman-machine port number
+
+```pwsh
+podman system connection list | Select-String 'ssh://\w+@[^:]+:(\d+)' | % { $_.Matches.Groups[1].Value }
+```
+
+### WSL - Ubuntu
+
+You can login with the port number, for example 53061
+
+```bash
+ssh user@localhost -p 53061
+```
+
 ## Why aren't these packages in winget list?
 
 - [micro](https://github.com/zyedidia/micro/issues/2339)

--- a/flake.nix
+++ b/flake.nix
@@ -74,49 +74,7 @@
             inherit pkgs;
             modules = [
               ./home-manager/kachick.nix
-
-              {
-                # https://github.com/nix-community/home-manager/blob/release-23.11/modules/systemd.nix#L161-L173
-                # Originally "system" should be better than "user", but it is not a home-manager role
-                systemd.user = {
-                  # - This name should be same of Mount.Where
-                  # - You can manually enable with `sudo systemctl enable ~/.config/systemd/user/mnt-wsl-instances-ubuntu22.mount --now`
-                  mounts.mnt-wsl-instances-ubuntu22 =
-                    # https://superuser.com/questions/1659218/is-there-a-way-to-access-files-from-one-wsl-2-distro-image-in-another-one
-                    {
-                      Unit = {
-                        Description = "Apply path that can be accessed from another WSL instance";
-                      };
-                      Mount = {
-                        What = "/";
-                        Where = "/mnt/wsl/instances/ubuntu22";
-                        Type = "none";
-                        Options = "defaults,bind,X-mount.mkdir";
-                      };
-                      Install = {
-                        WantedBy = [ "multi-user.target" ];
-                      };
-                    };
-
-                  # - Set sameme of Mount definition
-                  # - You can manually enable with `systemctl enable --now mount-point.automount`
-                  automounts.mnt-wsl-instances-ubuntu22 = {
-                    Mount = {
-                      Where = "/mnt/wsl/instances/ubuntu22";
-                    };
-                    Install = {
-                      WantedBy = [ "multi-user.target" ];
-                    };
-                  };
-                };
-
-                home.packages =
-                  (import ./home-manager/packages.nix {
-                    inherit pkgs;
-                    inherit edge-pkgs;
-                  })
-                  ++ [ pkgs.wslu ];
-              }
+              ./home-manager/wsl.nix
             ];
             extraSpecialArgs = {
               inherit edge-pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,59 @@
             };
           };
 
+          wsl = home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              ./home-manager/kachick.nix
+
+              {
+                # https://github.com/nix-community/home-manager/blob/release-23.11/modules/systemd.nix#L161-L173
+                # Originally "system" should be better than "user", but it is not a home-manager role
+                systemd.user = {
+                  # - This name should be same of Mount.Where
+                  # - You can manually enable with `sudo systemctl enable ~/.config/systemd/user/mnt-wsl-instances-ubuntu22.mount --now`
+                  mounts.mnt-wsl-instances-ubuntu22 =
+                    # https://superuser.com/questions/1659218/is-there-a-way-to-access-files-from-one-wsl-2-distro-image-in-another-one
+                    {
+                      Unit = {
+                        Description = "Apply path that can be accessed from another WSL instance";
+                      };
+                      Mount = {
+                        What = "/";
+                        Where = "/mnt/wsl/instances/ubuntu22";
+                        Type = "none";
+                        Options = "defaults,bind,X-mount.mkdir";
+                      };
+                      Install = {
+                        WantedBy = [ "multi-user.target" ];
+                      };
+                    };
+
+                  # - Set sameme of Mount definition
+                  # - You can manually enable with `systemctl enable --now mount-point.automount`
+                  automounts.mnt-wsl-instances-ubuntu22 = {
+                    Mount = {
+                      Where = "/mnt/wsl/instances/ubuntu22";
+                    };
+                    Install = {
+                      WantedBy = [ "multi-user.target" ];
+                    };
+                  };
+                };
+
+                home.packages =
+                  (import ./home-manager/packages.nix {
+                    inherit pkgs;
+                    inherit edge-pkgs;
+                  })
+                  ++ [ pkgs.wslu ];
+              }
+            ];
+            extraSpecialArgs = {
+              inherit edge-pkgs;
+            };
+          };
+
           github-actions = home-manager.lib.homeManagerConfiguration {
             inherit pkgs;
             modules = [
@@ -87,10 +140,7 @@
             inherit pkgs;
             modules = [
               ./home-manager/common.nix
-              {
-                # "user" is default in podman-machine-default
-                home.username = "user";
-              }
+              { home.username = "user"; }
             ];
             extraSpecialArgs = {
               inherit edge-pkgs;

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -2,19 +2,19 @@
   config,
   pkgs,
   edge-pkgs,
+  lib,
   ...
 }:
 
 {
   imports = [
-    ./packages.nix
     ./bash.nix
     ./zsh.nix
     ./fish.nix
     ./gpg.nix
     ./ssh.nix
     ./git.nix
-    ./darwin.nix # Omit needless parts for Linux in the file
+    ./darwin.nix
   ];
 
   # home.username = "<UPDATE_ME_IN_FLAKE>";
@@ -62,6 +62,11 @@
       # Put executable for temporary use
       "${config.xdg.dataHome}/tmpbin"
     ];
+
+    packages = import ./packages.nix {
+      inherit pkgs;
+      inherit edge-pkgs;
+    };
   };
 
   # https://github.com/nix-community/home-manager/issues/605

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -88,6 +88,8 @@
       _7zz # `7zz` 7zip, not
       tlrc # `tldr` rust client, tealdeer is another candidate
 
+      rclone
+
       # How to get the installed font names
       # fontconfig by nix: `fc-list : family style`
       # darwin: system_profiler SPFontsDataType

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -1,146 +1,138 @@
-{
-  pkgs,
-  edge-pkgs,
-  lib,
-  ...
-}:
+{ pkgs, edge-pkgs, ... }:
 
-{
-  # Prefer stable pkgs as possible, if you want to use edge pkgs
-  #   - Keep zero or tiny config in home-manager layer
-  #   - Set `mod-name.package = edge-pkgs.the-one;`
-  home.packages =
-    with pkgs;
-    [
-      # Use `bashInteractive`, don't `bash` - https://github.com/NixOS/nixpkgs/issues/29960, https://github.com/NixOS/nix/issues/730
-      # bash
-      # https://github.com/NixOS/nix/issues/730#issuecomment-162323824
-      bashInteractive
-      # readline # needless and using it does not fix bash problems
-      zsh
-      fish
-      powershell # Keep to stable nixpkgs, because this is one of the depending to xz. See #530
-      starship
-      direnv
-      zoxide # Used in alias `z`, alt cd/pushd. popd = `z -`, fzf-mode = `zi`
+# Prefer stable pkgs as possible, if you want to use edge pkgs
+#   - Keep zero or tiny config in home-manager layer
+#   - Set `mod-name.package = edge-pkgs.the-one;`
+with pkgs;
+[
+  # Use `bashInteractive`, don't `bash` - https://github.com/NixOS/nixpkgs/issues/29960, https://github.com/NixOS/nix/issues/730
+  # bash
+  # https://github.com/NixOS/nix/issues/730#issuecomment-162323824
+  bashInteractive
+  # readline # needless and using it does not fix bash problems
+  zsh
+  fish
+  powershell # Keep to stable nixpkgs, because this is one of the depending to xz. See #530
+  starship
+  direnv
+  zoxide # Used in alias `z`, alt cd/pushd. popd = `z -`, fzf-mode = `zi`
 
-      # Using in stable home-manager integration, but using edge fzf here.
-      # Because strongly want to use the new features. Consider to translate Nix -> native config style
-      edge-pkgs.fzf # History: CTRL+R, Walker: CTRL+T
-      # https://github.com/junegunn/fzf/blob/d579e335b5aa30e98a2ec046cb782bbb02bc28ad/ADVANCED.md#key-bindings-for-git-objects
-      # CTRL+O does not open web browser in WSL: https://github.com/kachick/dotfiles/issues/499
-      edge-pkgs.fzf-git-sh # CTRL-G CTRL-{} keybinds for git
+  # Using in stable home-manager integration, but using edge fzf here.
+  # Because strongly want to use the new features. Consider to translate Nix -> native config style
+  edge-pkgs.fzf # History: CTRL+R, Walker: CTRL+T
+  # https://github.com/junegunn/fzf/blob/d579e335b5aa30e98a2ec046cb782bbb02bc28ad/ADVANCED.md#key-bindings-for-git-objects
+  # CTRL+O does not open web browser in WSL: https://github.com/kachick/dotfiles/issues/499
+  edge-pkgs.fzf-git-sh # CTRL-G CTRL-{} keybinds for git
 
-      # Used in anywhere
-      coreutils
-      less # container base image doesn't have less even for ubuntu official
-      procps # `ps`
+  # Used in anywhere
+  coreutils
+  less # container base image doesn't have less even for ubuntu official
+  procps # `ps`
 
-      # Use same tools even in macOS
-      findutils
-      diffutils
-      gnugrep
-      gnused
-      gawk
-      netcat # `nc`
+  # Use same tools even in macOS
+  findutils
+  diffutils
+  gnugrep
+  gnused
+  gawk
+  netcat # `nc`
 
-      edge-pkgs.mise # alt asdf
+  edge-pkgs.mise # alt asdf
 
-      git
-      gh
-      ghq
+  git
+  gh
+  ghq
 
-      # GPG
-      gnupg
+  # GPG
+  gnupg
 
-      # Do not specify vim and the plugins at here, it made collisions from home-manager vim module.
-      # See following issues
-      # - https://github.com/kachick/dotfiles/issues/280
-      # - https://discourse.nixos.org/t/home-manager-neovim-collision/16963/2
+  # Do not specify vim and the plugins at here, it made collisions from home-manager vim module.
+  # See following issues
+  # - https://github.com/kachick/dotfiles/issues/280
+  # - https://discourse.nixos.org/t/home-manager-neovim-collision/16963/2
 
-      micro # alt nano
+  micro # alt nano
 
-      tree
-      eza # alt ls
-      curl
-      wget
-      jq
-      edge-pkgs.jnv # interactive jq
-      ripgrep # `rg`
-      bat # alt cat
-      hexyl # hex viewer
-      dysk # alt df
-      fd # alt find
-      du-dust # `dust`, alt du
-      procs
-      bottom # `btm`, alt top
-      xh # alt HTTPie
-      zellij
-      edge-pkgs.alacritty
-      edge-pkgs.typos
-      hyperfine
-      difftastic
-      gnumake
-      gitleaks
-      edge-pkgs.deno
-      edge-pkgs.ruby_3_3
-      unzip # Required in many asdf plugins
-      _7zz # `7zz` 7zip, not
-      tlrc # `tldr` rust client, tealdeer is another candidate
+  tree
+  eza # alt ls
+  curl
+  wget
+  jq
+  edge-pkgs.jnv # interactive jq
+  ripgrep # `rg`
+  bat # alt cat
+  hexyl # hex viewer
+  dysk # alt df
+  fd # alt find
+  du-dust # `dust`, alt du
+  procs
+  bottom # `btm`, alt top
+  xh # alt HTTPie
+  zellij
+  edge-pkgs.alacritty
+  edge-pkgs.typos
+  hyperfine
+  difftastic
+  gnumake
+  gitleaks
+  edge-pkgs.deno
+  edge-pkgs.ruby_3_3
+  unzip # Required in many asdf plugins
+  _7zz # `7zz` 7zip, not
+  tlrc # `tldr` rust client, tealdeer is another candidate
 
-      rclone
+  rclone
 
-      # How to get the installed font names
-      # fontconfig by nix: `fc-list : family style`
-      # darwin: system_profiler SPFontsDataType
-      fontconfig # `fc-list`, `fc-cache`
+  # How to get the installed font names
+  # fontconfig by nix: `fc-list : family style`
+  # darwin: system_profiler SPFontsDataType
+  fontconfig # `fc-list`, `fc-cache`
 
-      # - You can use major Nerd Fonts as `pkgs.nerdfonts.override ...`
-      # - Should have at least 1 composite font that includes Monospace + Japanese + Nerd fonts,
-      #   because of alacritty does not have the fallback font feature. https://github.com/alacritty/alacritty/issues/957
-      # - Keep fewer nerd fonts to reduce disk space
+  # - You can use major Nerd Fonts as `pkgs.nerdfonts.override ...`
+  # - Should have at least 1 composite font that includes Monospace + Japanese + Nerd fonts,
+  #   because of alacritty does not have the fallback font feature. https://github.com/alacritty/alacritty/issues/957
+  # - Keep fewer nerd fonts to reduce disk space
 
-      # You can also use 0 = `Slashed zero style` with enabling `"editor.fontLigatures": "'zero'"` in vscode
-      # but cannot use it in alacritty https://github.com/alacritty/alacritty/issues/50
-      edge-pkgs.plemoljp-nf
-      pkgs.ibm-plex # For sans-serif, use plemoljp for developing
+  # You can also use 0 = `Slashed zero style` with enabling `"editor.fontLigatures": "'zero'"` in vscode
+  # but cannot use it in alacritty https://github.com/alacritty/alacritty/issues/50
+  edge-pkgs.plemoljp-nf
+  pkgs.ibm-plex # For sans-serif, use plemoljp for developing
 
-      pkgs.source-han-code-jp # Includes many definitions, useful for fallback
-      pkgs.inconsolata
-      pkgs.mplus-outline-fonts.githubRelease # https://github.com/NixOS/nixpkgs/blob/c56f470377573b3170b62242ce21abcc196cb4ef/pkgs/data/fonts/mplus-outline-fonts/default.nix#L33
-      # pkgs.sarasa-gothic # Large filesize
+  pkgs.source-han-code-jp # Includes many definitions, useful for fallback
+  pkgs.inconsolata
+  pkgs.mplus-outline-fonts.githubRelease # https://github.com/NixOS/nixpkgs/blob/c56f470377573b3170b62242ce21abcc196cb4ef/pkgs/data/fonts/mplus-outline-fonts/default.nix#L33
+  # pkgs.sarasa-gothic # Large filesize
 
-      # Includes follows in each repository if needed, not in global
-      # gcc
-      # rustup
-      # go
-      # crystal
-      # elmPackages.elm
-      # sqlite
-      # postgresql
-      # cargo-make
+  # Includes follows in each repository if needed, not in global
+  # gcc
+  # rustup
+  # go
+  # crystal
+  # elmPackages.elm
+  # sqlite
+  # postgresql
+  # cargo-make
 
-      # If you need to build cruby from source, this section may remind the struggle
-      # Often failed to build cruby even if I enabled following dependencies
-      # zlib
-      # libyaml
-      # openssl
-    ]
-    ++ (import ./homemade.nix {
-      inherit pkgs;
-      inherit edge-pkgs;
-    })
-    ++ (lib.optionals stdenv.isLinux [
-      # Fix missing locales as `locale: Cannot set LC_CTYPE to default locale`
-      glibc
+  # If you need to build cruby from source, this section may remind the struggle
+  # Often failed to build cruby even if I enabled following dependencies
+  # zlib
+  # libyaml
+  # openssl
+]
+++ (import ./homemade.nix {
+  inherit pkgs;
+  inherit edge-pkgs;
+})
+++ (lib.optionals stdenv.isLinux [
+  # Fix missing locales as `locale: Cannot set LC_CTYPE to default locale`
+  glibc
 
-      # https://github.com/nix-community/home-manager/blob/a8f8f48320c64bd4e3a266a850bbfde2c6fe3a04/modules/services/ssh-agent.nix#L37
-      openssh
+  # https://github.com/nix-community/home-manager/blob/a8f8f48320c64bd4e3a266a850bbfde2c6fe3a04/modules/services/ssh-agent.nix#L37
+  openssh
 
-      iputils # `ping` etc
-    ])
-    ++ (lib.optionals stdenv.isDarwin [
-      # https://github.com/NixOS/nixpkgs/issues/240819
-      pinentry_mac
-    ]);
-}
+  iputils # `ping` etc
+])
+++ (lib.optionals stdenv.isDarwin [
+  # https://github.com/NixOS/nixpkgs/issues/240819
+  pinentry_mac
+])

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -6,6 +6,11 @@ let
   #   - https://wiki.archlinux.jp/index.php/XDG_Base_Directory
   #   - https://superuser.com/a/1606519/120469
   sshDir = "${config.home.homeDirectory}/.ssh";
+  sharedConfig = {
+    identityFile = "${sshDir}/id_ed25519";
+    identitiesOnly = true;
+    user = "git";
+  };
 in
 # - id_*: Do NOT share in different machines, do NOT tell to anyone. They are secrets.
 # - id_*.pub: I CAN register them for different services.
@@ -56,7 +61,7 @@ in
 
       PasswordAuthentication no
 
-      # default: "ask" - I'm disabling it for now
+      # default: "ask"
       StrictHostKeyChecking yes
 
       # https://serverfault.com/a/1109184/112217
@@ -70,34 +75,18 @@ in
     # No problem to register the same *.pub in different services
     matchBlocks = {
       # ANYONE can access the registered public key at https://github.com/kachick.keys
-      "github.com" = {
-        identityFile = "${sshDir}/id_ed25519";
-        identitiesOnly = true;
-        user = "git";
-      };
+      "github.com" = sharedConfig;
 
       # ANYONE can access the registered public key at https://gitlab.com/kachick.keys
-      "gitlab.com" = {
-        identityFile = "${sshDir}/id_ed25519";
-        identitiesOnly = true;
-        user = "git";
-      };
+      "gitlab.com" = sharedConfig;
 
       # Need authentication to get the public keys
       #   - https://stackoverflow.com/questions/23396870/can-i-get-ssh-public-key-from-url-in-bitbucket
       #   - https://developer.atlassian.com/cloud/bitbucket/rest/api-group-ssh/#api-users-selected-user-ssh-keys-get
-      "bitbucket.org" = {
-        identityFile = "${sshDir}/id_ed25519";
-        identitiesOnly = true;
-        user = "git";
-      };
+      "bitbucket.org" = sharedConfig;
 
       # For WSL2 instances like default Ubuntu and podman-machine
-      "localhost" = {
-        identityFile = "${sshDir}/id_ed25519";
-        identitiesOnly = true;
-        user = "git";
-
+      "localhost" = sharedConfig // {
         extraOptions = {
           StrictHostKeyChecking = "no";
           UserKnownHostsFile = "/dev/null";

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -91,6 +91,18 @@ in
         identitiesOnly = true;
         user = "git";
       };
+
+      # For WSL2 instances like default Ubuntu and podman-machine
+      "localhost" = {
+        identityFile = "${sshDir}/id_ed25519";
+        identitiesOnly = true;
+        user = "git";
+
+        extraOptions = {
+          StrictHostKeyChecking = "no";
+          UserKnownHostsFile = "/dev/null";
+        };
+      };
     };
   };
 }

--- a/home-manager/wsl.nix
+++ b/home-manager/wsl.nix
@@ -1,0 +1,44 @@
+{ pkgs, edge-pkgs, ... }:
+
+{
+  # https://github.com/nix-community/home-manager/blob/release-23.11/modules/systemd.nix#L161-L173
+  # Originally "system" should be better than "user", but it is not a home-manager role
+  systemd.user = {
+    # - This name should be same of Mount.Where
+    # - You can manually enable with `sudo systemctl enable ~/.config/systemd/user/mnt-wsl-instances-ubuntu22.mount --now`
+    mounts.mnt-wsl-instances-ubuntu22 =
+      # https://superuser.com/questions/1659218/is-there-a-way-to-access-files-from-one-wsl-2-distro-image-in-another-one
+      {
+        Unit = {
+          Description = "Apply path that can be accessed from another WSL instance";
+        };
+        Mount = {
+          What = "/";
+          Where = "/mnt/wsl/instances/ubuntu22";
+          Type = "none";
+          Options = "defaults,bind,X-mount.mkdir";
+        };
+        Install = {
+          WantedBy = [ "multi-user.target" ];
+        };
+      };
+
+    # - Set sameme of Mount definition
+    # - You can manually enable with `systemctl enable --now mount-point.automount`
+    automounts.mnt-wsl-instances-ubuntu22 = {
+      Mount = {
+        Where = "/mnt/wsl/instances/ubuntu22";
+      };
+      Install = {
+        WantedBy = [ "multi-user.target" ];
+      };
+    };
+  };
+
+  home.packages =
+    (import ./packages.nix {
+      inherit pkgs;
+      inherit edge-pkgs;
+    })
+    ++ [ pkgs.wslu ];
+}


### PR DESCRIPTION
Resolves #564
Resolves #563
Updates #499

Initially, I tried to resolve the problem with SSH and rclone mount.
Next, I switched to applying the `/mnt/wsl/instances/` path for that.
The second method looks good to me, but I am keeping rclone era for now. That is useful for non-WSL environments and cloud sync.