### PR TITLE
Introduce markdownlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16
         with:
           globs: '**/*.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,3 +39,11 @@ jobs:
           token: ${{ github.token }}
           version: '0.20.0' # selfup {"extract":"\\d\\.\\d+\\.\\d+","replacer":["stylua", "--version"], "nth": 2}
           args: --check .
+
+  markdownlint:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16
+        with:
+          globs: '**/*.md'

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,3 +2,6 @@ config:
   default: true
   # MD013/line-length
   MD013: false
+
+# Disabling for git commit hook
+noProgress: true

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,4 @@
+config:
+  default: true
+  # MD013/line-length
+  MD013: false

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,6 +2,3 @@ config:
   default: true
   # MD013/line-length
   MD013: false
-
-# Disabling for git commit hook
-noProgress: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "golang.go",
     "bmalehorn.vscode-fish",
     "kdl-org.kdl",
-    "JohnnyMorganz.stylua"
+    "JohnnyMorganz.stylua",
+    "davidanson.vscode-markdownlint"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -50,22 +50,30 @@ Some tools are not yet fully automated, read each docs.
 ## Ubuntu
 
 1. Install [Nix](https://nixos.org/) package manager with [DeterminateSystems/nix-installer](https://github.com/DeterminateSystems/nix-installer) to enable [Flakes](https://nixos.wiki/wiki/Flakes) by default.
+
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
    ```
+
 1. Make sure there is a nix directory that is used in the home-manager.\
    This is a workaround, See [the thread](https://www.reddit.com/r/Nix/comments/1443k3o/comment/jr9ht5g/?utm_source=reddit&utm_medium=web2x&context=3) for detail
+
    ```bash
    mkdir -p ~/.local/state/nix/profiles
    ```
+
 1. Restart current shell to load Nix as a PATH
+
    ```bash
    bash
    ```
+
 1. Apply dotfiles for each use
+
    ```bash
    nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#user@linux'
    ```
+
    Candidates
    - `user@linux` # Used in container
    - `kachick@linux`
@@ -74,7 +82,7 @@ Some tools are not yet fully automated, read each docs.
 
 1. Install uidmap without Nix for use of podman even if the podman will be installed from nixpkgs
 
-   - "shadow" in nixpkg is not enough for podman - https://github.com/NixOS/nixpkgs/issues/138423
+   - "shadow" in nixpkg is not enough for podman - <https://github.com/NixOS/nixpkgs/issues/138423>
 
    ```bash
    sudo apt-get install --assume-yes uidmap

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -18,6 +18,7 @@ func main() {
 	walker := fileutils.GetWalker()
 
 	bashPaths := walker.GetAllBash()
+	markdownPaths := walker.GetAllMarkdown()
 
 	cmds := runner.Commands{
 		{Path: "shellcheck", Args: bashPaths},
@@ -26,6 +27,7 @@ func main() {
 		{Path: "gitleaks", Args: []string{"detect", "--no-git"}},
 		{Path: "go", Args: []string{"vet", "./..."}},
 		{Path: "nixpkgs-lint", Args: []string{"."}},
+		{Path: "markdownlint-cli2", Args: markdownPaths},
 	}
 
 	if *allFlag {

--- a/config/Firefox/README.md
+++ b/config/Firefox/README.md
@@ -2,7 +2,7 @@
 
 ## How to change finder in page position from bottom to top?
 
-In Nix, we can define this step with https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/firefox.nix
+In Nix, we can define this step with <https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/firefox.nix>
 
 1. `about:config`
 1. Enable `toolkit.legacyUserProfileCustomizations.stylesheets`

--- a/config/alacritty/README.md
+++ b/config/alacritty/README.md
@@ -29,4 +29,4 @@ And you can test with actual toml in the `$HOME/.config/alacritty/local.toml`
 
 ## Can I list runtime config?
 
-No. See https://github.com/alacritty/alacritty/issues/7147
+No. See <https://github.com/alacritty/alacritty/issues/7147>

--- a/config/vscode/README.md
+++ b/config/vscode/README.md
@@ -1,3 +1,5 @@
+# vscode
+
 ## How to bulk install extensions without cloud sync
 
 ```bash

--- a/config/vscode/extensions.txt
+++ b/config/vscode/extensions.txt
@@ -23,3 +23,4 @@ task.vscode-task
 tekumara.typos-vscode
 timonwong.shellcheck
 veelenga.crystal-ameba
+davidanson.vscode-markdownlint

--- a/config/wezterm/README.md
+++ b/config/wezterm/README.md
@@ -1,3 +1,5 @@
+# WezTerm
+
 ## How to debug Lua code?
 
 CTRL-SHIFT-L

--- a/config/wezterm/README.md
+++ b/config/wezterm/README.md
@@ -2,6 +2,6 @@
 
 CTRL-SHIFT-L
 
-https://github.com/wez/wezterm/commit/23097993e51029f683f7d4a7d8fcf7e1725c6893
+<https://github.com/wez/wezterm/commit/23097993e51029f683f7d4a7d8fcf7e1725c6893>
 
 But you may need to disable the hotkey in AMD software. It is preserved in performance logging

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,3 +1,5 @@
+# Containers
+
 ## How to build and test in local
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          edge-pkgs = edge-nixpkgs.legacyPackages.${system};
         in
         {
           default =
@@ -94,6 +95,7 @@
                 go_1_22
                 goreleaser
                 trivy
+                edge-pkgs.markdownlint-cli2
               ];
             };
         }

--- a/internal/fileutils/walker.go
+++ b/internal/fileutils/walker.go
@@ -56,3 +56,15 @@ func (w Walker) GetAllBash() []string {
 
 	return paths
 }
+
+func (w Walker) GetAllMarkdown() []string {
+	paths := []string{}
+
+	for _, r := range w.reports {
+		if !r.Dir.IsDir() && strings.HasSuffix(r.Dir.Name(), ".md") {
+			paths = append(paths, r.Path)
+		}
+	}
+
+	return paths
+}

--- a/nixos/OneDrive.md
+++ b/nixos/OneDrive.md
@@ -1,4 +1,4 @@
-https://nixos.wiki/wiki/OneDrive
+<https://nixos.wiki/wiki/OneDrive>
 
 ```bash
 onedrive

--- a/nixos/OneDrive.md
+++ b/nixos/OneDrive.md
@@ -1,3 +1,5 @@
+# Onedrive
+
 <https://nixos.wiki/wiki/OneDrive>
 
 ```bash

--- a/nixos/WARP.md
+++ b/nixos/WARP.md
@@ -2,7 +2,7 @@ TODO: Replace this document with NixOS module since using [NixOS 24.11](https://
 
 Just installing as [this](https://github.com/NixOS/nixpkgs/issues/213177#issuecomment-1905556283) does not start connections.
 
-You should https://developers.cloudflare.com/warp-client/get-started/linux/
+You should <https://developers.cloudflare.com/warp-client/get-started/linux/>
 
 ```bash
 warp-cli registration new

--- a/nixos/WARP.md
+++ b/nixos/WARP.md
@@ -1,3 +1,5 @@
+# Cloudflare WARP
+
 TODO: Replace this document with NixOS module since using [NixOS 24.11](https://github.com/NixOS/nixpkgs/pull/321142)
 
 Just installing as [this](https://github.com/NixOS/nixpkgs/issues/213177#issuecomment-1905556283) does not start connections.

--- a/pkgs/fzf.md
+++ b/pkgs/fzf.md
@@ -2,6 +2,6 @@
 
 - `--preview`: the placeholder will be quoted by singlequote, so do not add excess double quote as "{}". This will be evaluated the given `` and $()
 - `--nth`: Match there
-- `--with-nth`: Whole display and outputs. None of only outputs: See https://github.com/junegunn/fzf/issues/1323
+- `--with-nth`: Whole display and outputs. None of only outputs: See <https://github.com/junegunn/fzf/issues/1323>
 - `--bind 'enter:become(...)'`: Replace process, and no execution if not match
 - `--ansi`: Handle colored input, but remember the output is dirty with the ANSI for another tools. You may need strip them before use.

--- a/windows/IME.md
+++ b/windows/IME.md
@@ -18,4 +18,4 @@ Cons for Microsoft IME
 
 ## How to toggle with US keyboard?
 
-- https://github.com/karakaram/alt-ime-ahk
+- <https://github.com/karakaram/alt-ime-ahk>

--- a/windows/Multi-booting.md
+++ b/windows/Multi-booting.md
@@ -12,7 +12,7 @@ Here is a note for me.
 
   Solutions
 
-  - https://superuser.com/a/1347749
+  - <https://superuser.com/a/1347749>
 
   In regedit and paste HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Power for the URL
   Make sure `HiberbootEnabled` is `0`, if not, change it from Control Panel

--- a/windows/Podman.md
+++ b/windows/Podman.md
@@ -39,7 +39,7 @@ podman run --volume /mnt/wsl/instances/ubuntu24/"$(pwd)":/workdir --workdir /wor
 
 ## After updating podman from 4.x -> 5.0.0, cannot do any operation even if the setup VM
 
-```
+```plaintext
 Error: Command execution failed with exit code 125 Command execution failed with exit code 125 Error: unable to load machine config file: "json: cannot unmarshal string into Go struct field MachineConfig.ImagePath of type define.VMFile"
 ```
 
@@ -74,37 +74,37 @@ This repository provides a mount based solution, mount from another instance as 
 
 ## How SSH login to podman-machine from another WSL instance like default Ubuntu?
 
-### WSL - Ubuntu
+1. WSL - Ubuntu
 
-Get pubkey
+   Get pubkey
 
-```bash
-cat ~/.ssh/id_ed25519.pub | clip.exe
-```
+   ```bash
+   cat ~/.ssh/id_ed25519.pub | clip.exe
+   ```
 
-### WSL - podman-machine
+2. WSL - podman-machine
 
-Register the Ubuntu pubkey
+   Register the Ubuntu pubkey
 
-```bash
-vi ~/.ssh/authorized_keys
-```
+   ```bash
+   vi ~/.ssh/authorized_keys
+   ```
 
-### Host - Windows
+3. Host - Windows
 
-Get podman-machine port number
+   Get podman-machine port number
 
-```pwsh
-podman system connection list | Select-String 'ssh://\w+@[^:]+:(\d+)' | % { $_.Matches.Groups[1].Value }
-```
+   ```pwsh
+   podman system connection list | Select-String 'ssh://\w+@[^:]+:(\d+)' | % { $_.Matches.Groups[1].Value }
+   ```
 
-### WSL - Ubuntu
+4. WSL - Ubuntu
 
-You can login with the port number, for example 53061
+   You can login with the port number, for example 53061
 
-```bash
-ssh user@localhost -p 53061
-```
+   ```bash
+   ssh user@localhost -p 53061
+   ```
 
 ## How mount client volume with podman-remote
 

--- a/windows/Podman.md
+++ b/windows/Podman.md
@@ -2,7 +2,7 @@
 
 ## How to resolve `WARN[0000] "/" is not a shared mount, this could cause issues or missing mounts with rootless containers`
 
-See https://github.com/containers/buildah/issues/3726#issuecomment-1171146242
+See <https://github.com/containers/buildah/issues/3726#issuecomment-1171146242>
 
 ```bash
 sudo mount --make-rshared /

--- a/windows/PowerShell.md
+++ b/windows/PowerShell.md
@@ -29,29 +29,29 @@ Loading personal and system profiles took 897ms.
 
 Reason: ngen.exe cannot compile latest pwsh
 
-- Official: https://github.com/PowerShell/PowerShell/issues/14374#issuecomment-1416688062
-- Better: https://superuser.com/a/1411591/120469
-- Didn't: https://stackoverflow.com/questions/59341482/powershell-steps-to-fix-slow-startup
-- How: https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26
+- Official: <https://github.com/PowerShell/PowerShell/issues/14374#issuecomment-1416688062>
+- Better: <https://superuser.com/a/1411591/120469>
+- Didn't: <https://stackoverflow.com/questions/59341482/powershell-steps-to-fix-slow-startup>
+- How: <https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26>
 
 One more noting, if you cannot find ngen.exe, dig under "C:\Windows\Microsoft.NET\Framework" as "C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 
 ## How to write PowerShell scripts?
 
-- https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines
-- https://github.com/MicrosoftDocs/PowerShell-Docs/blob/a5caf0d1104144f66ea0d7b9e8b2980cf9c605e9/reference/docs-conceptual/community/contributing/powershell-style-guide.md
-- https://github.com/kachick/learn_PowerShell
+- <https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines>
+- <https://github.com/MicrosoftDocs/PowerShell-Docs/blob/a5caf0d1104144f66ea0d7b9e8b2980cf9c605e9/reference/docs-conceptual/community/contributing/powershell-style-guide.md>
+- <https://github.com/kachick/learn_PowerShell>
 
 ## History substring search in major shells for Windows
 
-- PowerShell: Using https://github.com/kelleyma49/PSFzf made much slow, prefer https://github.com/kachick/PSFzfHistory
+- PowerShell: Using <https://github.com/kelleyma49/PSFzf> made much slow, prefer <https://github.com/kachick/PSFzfHistory>
 - nushell: But [it also does not have substring search like a zsh](https://github.com/nushell/nushell/discussions/7968)
 
 ## How to write PowerShell scripts?
 
-- https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines
-- https://github.com/MicrosoftDocs/PowerShell-Docs/blob/a5caf0d1104144f66ea0d7b9e8b2980cf9c605e9/reference/docs-conceptual/community/contributing/powershell-style-guide.md
-- https://github.com/kachick/learn_PowerShell
+- <https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines>
+- <https://github.com/MicrosoftDocs/PowerShell-Docs/blob/a5caf0d1104144f66ea0d7b9e8b2980cf9c605e9/reference/docs-conceptual/community/contributing/powershell-style-guide.md>
+- <https://github.com/kachick/learn_PowerShell>
 
 ## How to get helps for PowerShell commands as `cmd --help` in Unix?
 
@@ -95,7 +95,7 @@ After completed tasks, disable it as follows
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
-## History in PowerShell does not work...
+## History in PowerShell does not work
 
 If PowerShell in WindowsTerminal displaying as below,
 
@@ -107,10 +107,10 @@ Cannot load PSReadline module.  Console is running without PSReadline.
 I have faced this problem when called `Set-ExecutionPolicy -ExecutionPolicy Undefined -Scope CurrentUser`.\
 Try to set the permission as `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
-https://github.com/microsoft/terminal/issues/7257#issuecomment-1107700978
+<https://github.com/microsoft/terminal/issues/7257#issuecomment-1107700978>
 
 ## Some PowerShell scripts did not change windows behaviors
 
-https://answers.microsoft.com/en-us/windows/forum/all/windows-registry-changes-is-a-restart-always/e131b560-1d03-4b12-a32c-50df2bf12752
+<https://answers.microsoft.com/en-us/windows/forum/all/windows-registry-changes-is-a-restart-always/e131b560-1d03-4b12-a32c-50df2bf12752>
 
 After registry editing, needs to restart windows or the process

--- a/windows/PowerShell.md
+++ b/windows/PowerShell.md
@@ -47,12 +47,6 @@ One more noting, if you cannot find ngen.exe, dig under "C:\Windows\Microsoft.NE
 - PowerShell: Using <https://github.com/kelleyma49/PSFzf> made much slow, prefer <https://github.com/kachick/PSFzfHistory>
 - nushell: But [it also does not have substring search like a zsh](https://github.com/nushell/nushell/discussions/7968)
 
-## How to write PowerShell scripts?
-
-- <https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines>
-- <https://github.com/MicrosoftDocs/PowerShell-Docs/blob/a5caf0d1104144f66ea0d7b9e8b2980cf9c605e9/reference/docs-conceptual/community/contributing/powershell-style-guide.md>
-- <https://github.com/kachick/learn_PowerShell>
-
 ## How to get helps for PowerShell commands as `cmd --help` in Unix?
 
 `Get-Help -Name New-Item`

--- a/windows/README.md
+++ b/windows/README.md
@@ -6,6 +6,7 @@ Basically following codes will be done in PowerShell
 
 1. Download the windows helper binaries from [GitHub releases](https://github.com/kachick/dotfiles/releases) or uploaded artifacts in [each workflow](https://github.com/kachick/dotfiles/actions/workflows/windows.yml) summary
 1. New session of pwsh
+
    ```pwsh
    ./winit-conf.exe run
 
@@ -17,7 +18,9 @@ Basically following codes will be done in PowerShell
    ./winit-reg.exe list
    ./winit-reg.exe run --all
    ```
+
 1. Install some tools
+
    ```pwsh
    # Basically this may be same output of above `winit-conf.exe` log
    # Pick-up the winget-*.json outputs
@@ -29,9 +32,10 @@ Basically following codes will be done in PowerShell
    winget import --import-file "C:\Users\YOU\AppData\Local\Temp\winitRANDOM2\winget-pkgs-storage.json"
    winget import --import-file "C:\Users\YOU\AppData\Local\Temp\winitRANDOM3\winget-pkgs-entertainment.json"
    ```
+
 1. Remove needless pre-installed tools. Pick up from [bulk-uninstall.ps](./winget/bulk-uninstall.ps1)
 1. Change Dropbox storage path from `C:\Users`, default path made problems in System Restore.\
-   See https://zmzlz.blogspot.com/2014/10/windows-dropbox.html for detail
+   See <https://zmzlz.blogspot.com/2014/10/windows-dropbox.html> for detail
 1. Enable Bitlocker and backup the restore key
 
 ## Workflow
@@ -40,4 +44,4 @@ Basically following codes will be done in PowerShell
 
 ## I forgot to backup Bitlocker restore key 😋
 
-https://account.microsoft.com/devices/recoverykey may help
+<https://account.microsoft.com/devices/recoverykey> may help

--- a/windows/glazewm/README.md
+++ b/windows/glazewm/README.md
@@ -1,2 +1,4 @@
+# GlazeWM
+
 This config maybe too old since I using komorebi instead.
 Just keeping settings for now, feel free to remove it.

--- a/windows/winget/README.md
+++ b/windows/winget/README.md
@@ -10,15 +10,15 @@ It may be better to remove some packages such as `Mozilla.Firefox.DeveloperEditi
 
 ## Which programs excluded winget-pkgs are needed?
 
-- https://github.com/karakaram/alt-ime-ahk
-- https://github.com/yuru7/PlemolJP
-- https://www.realforce.co.jp/support/download/
-- https://www.kensington.com/ja-jp/software/kensingtonworks/#download # [winget cannot support v3.1.8+](https://github.com/microsoft/winget-pkgs/pull/136817)
-- https://www.kioxia.com/ja-jp/personal/software/ssd-utility.html
+- <https://github.com/karakaram/alt-ime-ahk>
+- <https://github.com/yuru7/PlemolJP>
+- <https://www.realforce.co.jp/support/download/>
+- <https://www.kensington.com/ja-jp/software/kensingtonworks/#download> # [winget cannot support v3.1.8+](https://github.com/microsoft/winget-pkgs/pull/136817)
+- <https://www.kioxia.com/ja-jp/personal/software/ssd-utility.html>
 
 ## Why avoiding winget to install Firefox Developer Edition?
 
 No Japanese locale is registered in winget yet, official installer is supporting.
 
-- https://github.com/kachick/times_kachick/issues/235
-- https://github.com/microsoft/winget-pkgs/tree/be851349a154acb14af6275812d79b70fadb9ddf/manifests/m/Mozilla/Firefox/DeveloperEdition/117.0b9
+- <https://github.com/kachick/times_kachick/issues/235>
+- <https://github.com/microsoft/winget-pkgs/tree/be851349a154acb14af6275812d79b70fadb9ddf/manifests/m/Mozilla/Firefox/DeveloperEdition/117.0b9>


### PR DESCRIPTION
- **Integrate markdownlint-cli2**
- **Add a linter intgeration [ci skip]**
- **Ignore unmeaningful line-length linter**
- **` markdownlint-cli2 --fix **/*.md`**
- **Manually fix markdownlint detections**
- **Clarify to use markdownlint in vscode extensions**
