### PR TITLE
Add a path reminder that temporarily saves the discarded commit message

### DIFF
--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -47,13 +47,9 @@
           meta.description = "#325";
           runtimeInputs = with pkgs; [ typos ];
           text = ''
-            # Check the diff first to avoid discarding original mesasges for retrying commits
-            if [ -n "$(typos --diff "$1")" ]; then
-              echo "$1"
-              cat "$1"
-              # Same check, but to exit error code with better message than diff
-              typos --config "${../typos.toml}" "$1"
-            fi
+            echo "original commit message has been saved at: $1"
+
+            typos --config "${../typos.toml}" "$1"
           '';
         }
       );

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -47,7 +47,13 @@
           meta.description = "#325";
           runtimeInputs = with pkgs; [ typos ];
           text = ''
-            typos --config "${../typos.toml}" "$1"
+            # Check the diff first to avoid discarding original mesasges for retrying commits
+            if [ -n "$(typos --diff "$1")" ]; then
+              echo "$1"
+              cat "$1"
+              # Same check, but to exit error code with better message than diff
+              typos --config "${../typos.toml}" "$1"
+            fi
           '';
         }
       );

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -47,9 +47,9 @@
           meta.description = "#325";
           runtimeInputs = with pkgs; [ typos ];
           text = ''
-            echo "original commit message has been saved at: $1"
+            set +o errexit
 
-            typos --config "${../typos.toml}" "$1"
+            typos --config "${../typos.toml}" "$1" || echo "original commit message: $1"
           '';
         }
       );


### PR DESCRIPTION
Resolves #682

- **Keep and display original message for git hook**
- **Just report the tmpfile path, basically ".git/COMMIT_EDITMSG"**
