### PR TITLE
Prevent to push branch which named with typo

### DIFF
--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -58,17 +58,16 @@
           name = "prevent_typos_in_branch_name.bash";
           meta.description = "#540";
           runtimeInputs = with pkgs; [
-            git
             typos
+            coreutils # `basename`
           ];
           # What arguments: https://git-scm.com/docs/githooks#_pre_push
           text = ''
-            while read -r local_ref _local_oid remote_ref _remote_oid
+            while read -r _local_ref _local_oid remote_ref _remote_oid
             do
-                {
-                  echo "$local_ref"
-                  echo "$remote_ref"
-                } | typos --config "${../typos.toml}" -
+              # Git ref is not a file path, but avoiding a typos bug for slash
+              # https://github.com/crate-ci/typos/issues/758
+              basename "$remote_ref" | typos --config "${../typos.toml}" -
             done
           '';
         }

--- a/home-manager/git.nix
+++ b/home-manager/git.nix
@@ -52,29 +52,24 @@
         }
       );
 
-      post-checkout = lib.getExe (
+      # Git does not provide hooks for renaming branch, so using in checkout phase is not enough
+      pre-push = lib.getExe (
         pkgs.writeShellApplication {
-          name = "alert_typos_in_branch_name.bash";
+          name = "prevent_typos_in_branch_name.bash";
           meta.description = "#540";
           runtimeInputs = with pkgs; [
             git
             typos
           ];
-          # What arguments: https://git-scm.com/docs/githooks#_post_checkout
+          # What arguments: https://git-scm.com/docs/githooks#_pre_push
           text = ''
-            is_file_checkout="$3" # 0: file, 1: branch
-            if [[ "$is_file_checkout" -eq 0 ]]; then
-              exit 0
-            fi
-
-            branch_name="$(git rev-parse --abbrev-ref 'HEAD')"
-
-            # Checkout to no branch and no tag
-            if [[ "$branch_name" = 'HEAD' ]]; then
-              exit 0
-            fi
-
-            (echo "$branch_name" | typos --config "${../typos.toml}" -) || true
+            while read -r local_ref _local_oid remote_ref _remote_oid
+            do
+                {
+                  echo "$local_ref"
+                  echo "$remote_ref"
+                } | typos --config "${../typos.toml}" -
+            done
           '';
         }
       );


### PR DESCRIPTION
Follow #540

- **Prevent to push branch which named with typo**
- **Avoid typos bug to handle slash**
