### PR TITLE
Fix pop-shell and GNOME basics conflicting

### DIFF
--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -58,22 +58,22 @@
         switch-to-application-1 = [ ];
         switch-to-application-2 = [ ];
         switch-to-application-3 = [ ];
-        switch-to-application-4 = [ ];
-        switch-to-application-5 = [ ];
-        switch-to-application-6 = [ ];
-        switch-to-application-7 = [ ];
-        switch-to-application-8 = [ ];
-        switch-to-application-9 = [ ];
+        # switch-to-application-4 = [ ];
+        # switch-to-application-5 = [ ];
+        # switch-to-application-6 = [ ];
+        # switch-to-application-7 = [ ];
+        # switch-to-application-8 = [ ];
+        # switch-to-application-9 = [ ];
 
         open-new-window-application-1 = [ ];
         open-new-window-application-2 = [ ];
         open-new-window-application-3 = [ ];
-        open-new-window-application-4 = [ ];
-        open-new-window-application-5 = [ ];
-        open-new-window-application-6 = [ ];
-        open-new-window-application-7 = [ ];
-        open-new-window-application-8 = [ ];
-        open-new-window-application-9 = [ ];
+        # open-new-window-application-4 = [ ];
+        # open-new-window-application-5 = [ ];
+        # open-new-window-application-6 = [ ];
+        # open-new-window-application-7 = [ ];
+        # open-new-window-application-8 = [ ];
+        # open-new-window-application-9 = [ ];
       };
 
       "org/gnome/desktop/wm/preferences" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -34,7 +34,7 @@
             auto-move-windows
             just-perfection
             dash-to-dock
-            color-picker
+            # color-picker # Don't enable by default. It conflicts with clipboard-history
           ]
         );
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -163,6 +163,8 @@
 
         # https://unix.stackexchange.com/questions/327975/how-to-change-the-gnome-panel-time-format
         clock-show-weekday = true;
+
+        gtk-theme = "Nordic";
       };
 
       "org/gnome/shell/extensions/dash-to-dock" = {
@@ -174,6 +176,10 @@
         multi-monitor = true;
       };
 
+      # Should be changed from default Adwaita to another to avoid https://github.com/pop-os/shell/issues/132
+      "org/gnome/desktop/wm/preferences" = {
+        theme = "Nordic";
+      };
     };
   };
 }

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -81,6 +81,8 @@
       };
 
       "org/gnome/desktop/wm/keybindings" = {
+        activate-window-menu = [ ]; # Disabling default `<Alt>space` to run launchers
+
         toggle-message-tray = [ "<Shift><Super>m" ]; # default: ['<Super>v', '<Super>m'], `"disable"` restore default. So added annoy modifier to prevent trigger
 
         switch-to-workspace-1 = [ "<Super>1" ];

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -45,34 +45,40 @@
         ];
       };
 
+      # https://unix.stackexchange.com/questions/481142/launch-default-terminal-emulator-by-command
+      "org/gnome/desktop/default-applications/terminal" = {
+        exec = lib.getExe pkgs.alacritty;
+        # exec-arg="";
+      };
+
       "org/gnome/desktop/wm/keybindings" = {
         toggle-message-tray = [ "<Shift><Super>m" ]; # default: ['<Super>v', '<Super>m'], `"disable"` restore default. So added annoy modifier to prevent trigger
       };
 
       "org/gnome/settings-daemon/plugins/media-keys" = {
-        control-center = [ "<Super>comma" ];
-        www = [ "<Super>w" ];
-        search = [ "<Super>f" ];
+        # control-center = [ "<Super>comma" ]; # I set this because of inspired by vscode, but disable to avoid conflict of pop-shell minimizerr
+        # www = [ "<Super>w" ]; # pop-shell sets to Super+b
+        # search = [ "<Super>f" ]; # pop-shell sets to file manager
         custom-keybindings = [
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
         ];
       };
 
-      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0" = {
-        name = "Terminal";
-        binding = "<Super>t";
-        command = lib.getExe pkgs.alacritty;
-      };
-
       "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1" = {
         name = "Resource Monitor - TUI";
-        binding = "<Super>b"; # I don't know why, <Super>m don't work even if removed other shortcuts :<
+        binding = "<Super>r";
         command = "${lib.getExe pkgs.alacritty} --command=${lib.getExe pkgs.bottom} --title='Resource Monitor(btm)'";
       };
 
+      # https://github.com/pop-os/shell/blob/master_noble/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
       "org/gnome/shell/extensions/pop-shell" = {
         tile-by-default = true;
+
+        # Keybindings: https://github.com/pop-os/shell/blob/master_noble/scripts/configure.sh
+
+        # https://www.reddit.com/r/pop_os/comments/mt5kgf/how_to_change_default_keybind_for/
+        activate-launcher = "['<Alt>space']";
       };
 
       "org/gnome/shell/extensions/clipboard-history" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -112,11 +112,11 @@
         # search = [ "<Super>f" ]; # pop-shell sets to file manager
         custom-keybindings = [
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
+          # "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
         ];
       };
 
-      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1" = {
+      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0" = {
         name = "Resource Monitor - TUI";
         binding = "<Super>r";
         command = "${lib.getExe pkgs.alacritty} --command=${lib.getExe pkgs.bottom} --title='Resource Monitor(btm)'";

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -34,6 +34,7 @@
             auto-move-windows
             just-perfection
             dash-to-dock
+            color-picker
           ]
         );
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -176,7 +176,6 @@
         multi-monitor = true;
       };
 
-      # Should be changed from default Adwaita to another to avoid https://github.com/pop-os/shell/issues/132
       "org/gnome/desktop/wm/preferences" = {
         theme = "Nordic";
       };

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -109,15 +109,21 @@
       "org/gnome/settings-daemon/plugins/media-keys" = {
         # control-center = [ "<Super>comma" ]; # I set this because of inspired by vscode, but disable to avoid conflict of pop-shell minimizerr
         www = [ "<Super>w" ]; # Prefer w even through pop-shell recommends to Super+b
-        terminal = [ "<Super>t" ];
+        # terminal = [ "<Super>t" ]; I don't know why this won't work. So use cosutom keybinding
         # search = [ "<Super>f" ]; # pop-shell sets to file manager
         custom-keybindings = [
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
-          # "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
+          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
         ];
       };
 
       "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0" = {
+        name = "Alacritty";
+        binding = "<Super>t";
+        command = lib.getExe pkgs.alacritty;
+      };
+
+      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1" = {
         name = "Resource Monitor - TUI";
         binding = "<Super>r";
         command = "${lib.getExe pkgs.alacritty} --command=${lib.getExe pkgs.bottom} --title='Resource Monitor(btm)'";

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -51,8 +51,57 @@
         # exec-arg="";
       };
 
+      # gsettings list-recursively | grep -F "<Super>"
+      # Disabling defaults to enable Suprt+num family will be used to switch workspaces
+      # https://github.com/pop-os/shell/issues/142
+      "org/gnome/shell/keybindings" = {
+        switch-to-application-1 = [ ];
+        switch-to-application-2 = [ ];
+        switch-to-application-3 = [ ];
+        switch-to-application-4 = [ ];
+        switch-to-application-5 = [ ];
+        switch-to-application-6 = [ ];
+        switch-to-application-7 = [ ];
+        switch-to-application-8 = [ ];
+        switch-to-application-9 = [ ];
+
+        open-new-window-application-1 = [ ];
+        open-new-window-application-2 = [ ];
+        open-new-window-application-3 = [ ];
+        open-new-window-application-4 = [ ];
+        open-new-window-application-5 = [ ];
+        open-new-window-application-6 = [ ];
+        open-new-window-application-7 = [ ];
+        open-new-window-application-8 = [ ];
+        open-new-window-application-9 = [ ];
+      };
+
+      "org/gnome/desktop/wm/preferences" = {
+        num-workspaces = 9;
+      };
+
       "org/gnome/desktop/wm/keybindings" = {
         toggle-message-tray = [ "<Shift><Super>m" ]; # default: ['<Super>v', '<Super>m'], `"disable"` restore default. So added annoy modifier to prevent trigger
+
+        switch-to-workspace-1 = "['<Super>1']";
+        switch-to-workspace-2 = "['<Super>2']";
+        switch-to-workspace-3 = "['<Super>3']";
+        switch-to-workspace-4 = "['<Super>4']";
+        switch-to-workspace-5 = "['<Super>5']";
+        switch-to-workspace-6 = "['<Super>6']";
+        switch-to-workspace-7 = "['<Super>7']";
+        switch-to-workspace-8 = "['<Super>8']";
+        switch-to-workspace-9 = "['<Super>9']";
+
+        move-to-workspace-1 = "['<Super><Shift>1']";
+        move-to-workspace-2 = "['<Super><Shift>2']";
+        move-to-workspace-3 = "['<Super><Shift>3']";
+        move-to-workspace-4 = "['<Super><Shift>4']";
+        move-to-workspace-5 = "['<Super><Shift>5']";
+        move-to-workspace-6 = "['<Super><Shift>6']";
+        move-to-workspace-7 = "['<Super><Shift>7']";
+        move-to-workspace-8 = "['<Super><Shift>8']";
+        move-to-workspace-9 = "['<Super><Shift>9']";
       };
 
       "org/gnome/settings-daemon/plugins/media-keys" = {
@@ -95,6 +144,8 @@
 
       "org/gnome/mutter" = {
         experimental-features = [ "scale-monitor-framebuffer" ];
+
+        dynamic-workspaces = false;
       };
 
       "org/gnome/desktop/interface" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -77,31 +77,31 @@
       };
 
       "org/gnome/desktop/wm/preferences" = {
-        num-workspaces = 9;
+        num-workspaces = 3;
       };
 
       "org/gnome/desktop/wm/keybindings" = {
         toggle-message-tray = [ "<Shift><Super>m" ]; # default: ['<Super>v', '<Super>m'], `"disable"` restore default. So added annoy modifier to prevent trigger
 
-        switch-to-workspace-1 = ["<Super>1"];
-        switch-to-workspace-2 = ["<Super>2"];
-        switch-to-workspace-3 = ["<Super>3"];
-        switch-to-workspace-4 = ["<Super>4"];
-        switch-to-workspace-5 = ["<Super>5"];
-        switch-to-workspace-6 = ["<Super>6"];
-        switch-to-workspace-7 = ["<Super>7"];
-        switch-to-workspace-8 = ["<Super>8"];
-        switch-to-workspace-9 = ["<Super>9"];
+        switch-to-workspace-1 = [ "<Super>1" ];
+        switch-to-workspace-2 = [ "<Super>2" ];
+        switch-to-workspace-3 = [ "<Super>3" ];
+        # switch-to-workspace-4 = [ "<Super>4" ];
+        # switch-to-workspace-5 = [ "<Super>5" ];
+        # switch-to-workspace-6 = [ "<Super>6" ];
+        # switch-to-workspace-7 = [ "<Super>7" ];
+        # switch-to-workspace-8 = [ "<Super>8" ];
+        # switch-to-workspace-9 = [ "<Super>9" ];
 
-        move-to-workspace-1 = ["<Super><Shift>1"];
-        move-to-workspace-2 = ["<Super><Shift>2"];
-        move-to-workspace-3 = ["<Super><Shift>3"];
-        move-to-workspace-4 = ["<Super><Shift>4"];
-        move-to-workspace-5 = ["<Super><Shift>5"];
-        move-to-workspace-6 = ["<Super><Shift>6"];
-        move-to-workspace-7 = ["<Super><Shift>7"];
-        move-to-workspace-8 = ["<Super><Shift>8"];
-        move-to-workspace-9 = ["<Super><Shift>9"];
+        move-to-workspace-1 = [ "<Super><Shift>1" ];
+        move-to-workspace-2 = [ "<Super><Shift>2" ];
+        move-to-workspace-3 = [ "<Super><Shift>3" ];
+        # move-to-workspace-4 = [ "<Super><Shift>4" ];
+        # move-to-workspace-5 = [ "<Super><Shift>5" ];
+        # move-to-workspace-6 = [ "<Super><Shift>6" ];
+        # move-to-workspace-7 = [ "<Super><Shift>7" ];
+        # move-to-workspace-8 = [ "<Super><Shift>8" ];
+        # move-to-workspace-9 = [ "<Super><Shift>9" ];
       };
 
       "org/gnome/settings-daemon/plugins/media-keys" = {
@@ -127,7 +127,7 @@
         # Keybindings: https://github.com/pop-os/shell/blob/master_noble/scripts/configure.sh
 
         # https://www.reddit.com/r/pop_os/comments/mt5kgf/how_to_change_default_keybind_for/
-        activate-launcher = ["<Alt>space"];
+        activate-launcher = [ "<Alt>space" ];
       };
 
       "org/gnome/shell/extensions/clipboard-history" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -83,25 +83,25 @@
       "org/gnome/desktop/wm/keybindings" = {
         toggle-message-tray = [ "<Shift><Super>m" ]; # default: ['<Super>v', '<Super>m'], `"disable"` restore default. So added annoy modifier to prevent trigger
 
-        switch-to-workspace-1 = "['<Super>1']";
-        switch-to-workspace-2 = "['<Super>2']";
-        switch-to-workspace-3 = "['<Super>3']";
-        switch-to-workspace-4 = "['<Super>4']";
-        switch-to-workspace-5 = "['<Super>5']";
-        switch-to-workspace-6 = "['<Super>6']";
-        switch-to-workspace-7 = "['<Super>7']";
-        switch-to-workspace-8 = "['<Super>8']";
-        switch-to-workspace-9 = "['<Super>9']";
+        switch-to-workspace-1 = ["<Super>1"];
+        switch-to-workspace-2 = ["<Super>2"];
+        switch-to-workspace-3 = ["<Super>3"];
+        switch-to-workspace-4 = ["<Super>4"];
+        switch-to-workspace-5 = ["<Super>5"];
+        switch-to-workspace-6 = ["<Super>6"];
+        switch-to-workspace-7 = ["<Super>7"];
+        switch-to-workspace-8 = ["<Super>8"];
+        switch-to-workspace-9 = ["<Super>9"];
 
-        move-to-workspace-1 = "['<Super><Shift>1']";
-        move-to-workspace-2 = "['<Super><Shift>2']";
-        move-to-workspace-3 = "['<Super><Shift>3']";
-        move-to-workspace-4 = "['<Super><Shift>4']";
-        move-to-workspace-5 = "['<Super><Shift>5']";
-        move-to-workspace-6 = "['<Super><Shift>6']";
-        move-to-workspace-7 = "['<Super><Shift>7']";
-        move-to-workspace-8 = "['<Super><Shift>8']";
-        move-to-workspace-9 = "['<Super><Shift>9']";
+        move-to-workspace-1 = ["<Super><Shift>1"];
+        move-to-workspace-2 = ["<Super><Shift>2"];
+        move-to-workspace-3 = ["<Super><Shift>3"];
+        move-to-workspace-4 = ["<Super><Shift>4"];
+        move-to-workspace-5 = ["<Super><Shift>5"];
+        move-to-workspace-6 = ["<Super><Shift>6"];
+        move-to-workspace-7 = ["<Super><Shift>7"];
+        move-to-workspace-8 = ["<Super><Shift>8"];
+        move-to-workspace-9 = ["<Super><Shift>9"];
       };
 
       "org/gnome/settings-daemon/plugins/media-keys" = {
@@ -127,7 +127,7 @@
         # Keybindings: https://github.com/pop-os/shell/blob/master_noble/scripts/configure.sh
 
         # https://www.reddit.com/r/pop_os/comments/mt5kgf/how_to_change_default_keybind_for/
-        activate-launcher = "['<Alt>space']";
+        activate-launcher = ["<Alt>space"];
       };
 
       "org/gnome/shell/extensions/clipboard-history" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -108,7 +108,8 @@
 
       "org/gnome/settings-daemon/plugins/media-keys" = {
         # control-center = [ "<Super>comma" ]; # I set this because of inspired by vscode, but disable to avoid conflict of pop-shell minimizerr
-        # www = [ "<Super>w" ]; # pop-shell sets to Super+b
+        www = [ "<Super>w" ]; # Prefer w even through pop-shell recommends to Super+b
+        terminal = [ "<Super>t" ];
         # search = [ "<Super>f" ]; # pop-shell sets to file manager
         custom-keybindings = [
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -88,6 +88,8 @@ with pkgs;
   _7zz # `7zz` 7zip, not
   tlrc # `tldr` rust client, tealdeer is another candidate
 
+  pastel
+
   rclone
 
   # How to get the installed font names

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -236,6 +236,7 @@
       kimpanel
       just-perfection
       dash-to-dock
+      color-picker
     ]);
 
   # https://github.com/NixOS/nixpkgs/issues/33282#issuecomment-523572259

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -222,7 +222,16 @@
     ++ (with pkgs.gnomeExtensions; [
       appindicator
       blur-my-shell
-      pop-shell
+
+      # Should be changed from default CSS to another to avoid https://github.com/pop-os/shell/issues/132
+      # https://github.com/pop-os/shell/blob/cfa0c55e84b7ce339e5ce83832f76fee17e99d51/light.css#L20-L24
+      (pop-shell.overrideAttrs (prev: {
+        preFixup =
+          prev.preFixup
+          + ''
+            echo '.pop-shell-search-element:select{ background: #005f5f !important; color: #d2d4de !important; }' >> $out/share/gnome-shell/extensions/pop-shell@system76.com/light.css
+          '';
+      }))
       clipboard-history
       kimpanel
       just-perfection

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -216,6 +216,8 @@
 
       # https://github.com/NixOS/nixpkgs/issues/174353 - Super + / runs launcher by default
       pop-launcher
+
+      nordic
     ]
     ++ (with pkgs.gnomeExtensions; [
       appindicator

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -225,11 +225,12 @@
 
       # Should be changed from default CSS to another to avoid https://github.com/pop-os/shell/issues/132
       # https://github.com/pop-os/shell/blob/cfa0c55e84b7ce339e5ce83832f76fee17e99d51/light.css#L20-L24
+      # Apple same color as nord(Nordic) https://github.com/EliverLara/Nordic/blob/5c53654fb6f3e0266ad8c481a099091e92f28274/gnome-shell/_colors.scss#L14-L15
       (pop-shell.overrideAttrs (prev: {
         preFixup =
           prev.preFixup
           + ''
-            echo '.pop-shell-search-element:select{ background: #005f5f !important; color: #d2d4de !important; }' >> $out/share/gnome-shell/extensions/pop-shell@system76.com/light.css
+            echo '.pop-shell-search-element:select{ background: #8fbcbb !important; color: #fefefe !important; }' >> $out/share/gnome-shell/extensions/pop-shell@system76.com/light.css
           '';
       }))
       clipboard-history

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -213,6 +213,9 @@
       cloudflare-warp
 
       gnome.dconf-editor
+
+      # https://github.com/NixOS/nixpkgs/issues/174353 - Super + / runs launcher by default
+      pop-launcher
     ]
     ++ (with pkgs.gnomeExtensions; [
       appindicator

--- a/nixos/xremap.nix
+++ b/nixos/xremap.nix
@@ -16,14 +16,15 @@
       }
     ];
 
+    # Disabled while using Alt-Space for pop-shell launcher
     # Keymap for key combo rebinds
-    keymap = [
-      {
-        name = "Gnome lancher";
-        remap = {
-          "Alt-Space" = "LEFTMETA";
-        };
-      }
-    ];
+    # keymap = [
+    #   {
+    #     name = "Gnome lancher";
+    #     remap = {
+    #       "Alt-Space" = "LEFTMETA";
+    #     };
+    #   }
+    # ];
   };
 }


### PR DESCRIPTION
- **Install pop-launcher**
- **Fix conflicting pop-shell and gnome keybindigns**
- **Assign Super+Num keybindings to switch/mode workspaces**
- **Fix syntax of specifying keybinds**
- **I cannot manage many workspaces**
- **Disable Alt-Space by xremap**
- **Disable default Alt+space gnome keybinds**
- **Disable removed custom keybind**
- **Enable keybinding to launch Firefox again**
- **Do not disable non conflicting keybinds**
- **Restore dropped custom keybinding for alacritty**
- **Use Nordic gnome theme to avoid pop-shell launcher styling problem**
- **Fix broken style combination with pop-shell launcher and gnome**
- **Install color pickers**
- **Disable conflicting color picker extension by default**
- **Adjust search color with Nordic**
