### PR TITLE
Apply forked cozette bitmap font for Linux console

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -13,7 +13,7 @@
 {
   imports = [
     (import ./font.nix { inherit pkgs homemade-pkgs; })
-    (import ./console.nix { inherit pkgs; })
+    (import ./console.nix { inherit homemade-pkgs; })
     (import ./language.nix { inherit config pkgs; })
   ];
 

--- a/nixos/console.nix
+++ b/nixos/console.nix
@@ -9,12 +9,9 @@
     earlySetup = true;
     # The font should have PSF formats. Do not specify TTF and OTF
     # You can list current glyphs with `showconsolefont`
-    font = "ter-u24n";
+    font = "${pkgs.cozette}/share/fonts/misc/cozette.psf";
 
-    packages = with pkgs; [
-      # https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/data/fonts/terminus-font/default.nix#L41-L43
-      terminus_font
-    ];
+    packages = with pkgs; [ cozette ];
     keyMap = "us";
   };
 

--- a/nixos/console.nix
+++ b/nixos/console.nix
@@ -2,16 +2,16 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ pkgs, ... }:
+{ homemade-pkgs, ... }:
 {
   # https://wiki.archlinux.org/title/Linux_console
   console = {
     earlySetup = true;
     # The font should have PSF formats. Do not specify TTF and OTF
     # You can list current glyphs with `showconsolefont`
-    font = "${pkgs.cozette}/share/fonts/misc/cozette.psf";
+    font = "${homemade-pkgs.cozette}/share/consolefonts/cozette.psf";
 
-    packages = with pkgs; [ cozette ];
+    packages = with homemade-pkgs; [ cozette ];
     keyMap = "us";
   };
 }

--- a/nixos/console.nix
+++ b/nixos/console.nix
@@ -14,23 +14,4 @@
     packages = with pkgs; [ cozette ];
     keyMap = "us";
   };
-
-  # Better console appearance even if no X, but do not use for now with the unstable behaviors
-  # https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/services/ttys/kmscon.nix
-  services.kmscon = {
-    enable = false;
-    hwRender = false;
-    fonts = with pkgs; [
-      {
-        name = "IBM Plex Mono";
-        package = ibm-plex;
-      }
-      {
-        name = "Noto Color Emoji";
-        package = noto-fonts-color-emoji;
-      }
-    ];
-    extraConfig = "font-size=24";
-    extraOptions = "--term xterm-256color";
-  };
 }

--- a/nixos/console.nix
+++ b/nixos/console.nix
@@ -9,7 +9,7 @@
     earlySetup = true;
     # The font should have PSF formats. Do not specify TTF and OTF
     # You can list current glyphs with `showconsolefont`
-    font = "${homemade-pkgs.cozette}/share/consolefonts/cozette.psf";
+    font = "${homemade-pkgs.cozette}/share/consolefonts/cozette_hidpi.psf";
 
     packages = with homemade-pkgs; [ cozette ];
     keyMap = "us";

--- a/pkgs/cozette/default.nix
+++ b/pkgs/cozette/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+# Patched because of nixpkgs does not include psf
+# https://github.com/NixOS/nixpkgs/blob/41d21a82c38e226e234e16f4ff213b3fcf85e6e9/pkgs/data/fonts/cozette/default.nix#L1C1-L33C2
+stdenvNoCC.mkDerivation rec {
+  pname = "cozette";
+  version = "1.25.1";
+
+  src = fetchzip {
+    url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts-v-${
+      builtins.replaceStrings [ "." ] [ "-" ] version
+    }.zip";
+    hash = "sha256-Cnl7DTPcZmCRM06qe7WXfZorok3uUNYcB9bR/auzCao=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.otf -t $out/share/fonts/opentype
+    install -Dm644 *.bdf -t $out/share/fonts/misc
+    install -Dm644 *.otb -t $out/share/fonts/misc
+    install -Dm644 *.woff -t $out/share/fonts/woff
+    install -Dm644 *.woff2 -t $out/share/fonts/woff2
+    install -Dm644 *.psf -t $out/share/consolefonts
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Bitmap programming font optimized for coziness";
+    homepage = "https://github.com/slavfox/cozette";
+    changelog = "https://github.com/slavfox/Cozette/blob/v.${version}/CHANGELOG.md";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [
+      brettlyons
+      kachick
+    ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -50,6 +50,7 @@
   };
 
   beedii = pkgs.callPackage ./beedii { };
+  cozette = pkgs.callPackage ./cozette { };
 
   posix_shared_functions = pkgs.callPackage ./posix_shared_functions { };
 


### PR DESCRIPTION
- **Replace terminus_font with cozette to display nerd font glyphs**
- **Uninstall inactive kmscon**
- **Apply forked cozette for Linux console**
- **Use Hi DPI font**

Related to GH-667 and GH-674

Still having Tofu for Kanji and Nerd font ares, but it is better than now
