### PR TITLE
Make Helix as the default TUI editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Check [traps](./windows/Multi-booting.md)
 
    ```bash
    touch ~/.ssh/id_ed25519 && chmod 400 ~/.ssh/id_ed25519
-   micro ~/.ssh/id_ed25519
+   hx ~/.ssh/id_ed25519
    ```
 
 1. [Restore encrypted rclone.conf from STDIN](config/rclone.md)

--- a/config/rclone.md
+++ b/config/rclone.md
@@ -30,7 +30,7 @@ Assume you encrypted the config
 
 ```bash
 rclone config touch
-micro "$(rclone config file | tail -1)"
+hx "$(rclone config file | tail -1)"
 ```
 
 Don't save the file in this repository even if it is encrypted with agenix or sops-nix.
@@ -43,7 +43,7 @@ Or directly set `RCLONE_CONFIG_PASS` as this.\
 (`read -s` does not work in zsh)
 
 ```bash
-export RCLONE_CONFIG_PASS="$(micro)"
+export RCLONE_CONFIG_PASS="$(hx)"
 ```
 
 ## Mount

--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -18,15 +18,15 @@ themes {
         orange 208 135 112 // #D08770
     }
 }
-default_mode "locked"
+// default_mode "locked"
 // candidates: https://github.com/zellij-org/zellij/blob/v0.39.2/zellij-utils/assets/config/default.kdl
 keybinds {
-    shared_except "locked" {
-        bind "Alt q" {
-            Quit
-        }
-        unbind "Ctrl q" //  conflict micro
-    }
+    // shared_except "locked" {
+    //     bind "Alt q" {
+    //         Quit
+    //     }
+    //     unbind "Ctrl q" //  conflict micro
+    // }
     // shared_except "resize" "locked" {
     //     // unbind "Ctrl n" //  conflict why n = resize
     // }

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -44,8 +44,8 @@
     sessionVariables = {
       # Do NOT set GIT_EDITOR, it overrides `core.editor` in git config
       # https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference
-      EDITOR = lib.getExe pkgs.micro; # If you forgot the keybind: https://github.com/zyedidia/micro/blob/c15abea64c20066fc0b4c328dfabd3e6ba3253a0/runtime/help/defaultkeys.md
-      VISUAL = lib.getExe pkgs.micro; # vscode is heavy even if in VISUAL use
+      EDITOR = lib.getExe pkgs.helix; # If you forgot the keybind: https://github.com/zyedidia/micro/blob/c15abea64c20066fc0b4c328dfabd3e6ba3253a0/runtime/help/defaultkeys.md
+      VISUAL = lib.getExe pkgs.helix; # vscode is heavy even if in VISUAL use
       PAGER = "less";
 
       # - You can check the candidates in `locale -a`

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -124,9 +124,9 @@
     # QT_IM_MODULE = "fcitx";
     XMODIFIERS = "@im=fcitx";
 
-    EDITOR = lib.getExe pkgs.micro;
-    SYSTEMD_EDITOR = lib.getExe pkgs.micro;
-    VISUAL = lib.getExe pkgs.micro;
+    EDITOR = lib.getExe pkgs.helix;
+    SYSTEMD_EDITOR = lib.getExe pkgs.helix;
+    VISUAL = lib.getExe pkgs.helix;
   };
 
   # List packages installed in system profile. To search, run:
@@ -135,8 +135,8 @@
     with pkgs;
     [
       vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
-      micro
       helix
+      micro
       edge-pkgs.zed-editor # version in nixos-24.05 does not enable IME
       lapce # IME is not working on Windows, but stable even around IME on Wayland than vscode
 

--- a/pkgs/todo/default.nix
+++ b/pkgs/todo/default.nix
@@ -5,7 +5,6 @@ pkgs.writeShellApplication rec {
   runtimeInputs = with pkgs; [
     git
     fzf
-    micro
     bat
   ];
   meta = {

--- a/pkgs/todo/todo.bash
+++ b/pkgs/todo/todo.bash
@@ -1,5 +1,6 @@
 # open bat with line number in preview: https://github.com/sharkdp/bat/issues/1185#issuecomment-1301473901
+# shellcheck disable=SC2016
 git grep --perl-regexp --line-number --column --color=always '\b(?<=TODO|FIXME|BUG)\b\S+' |
 	fzf --ansi --delimiter : --nth 4.. \
 		--preview 'bat {1} --color=always --highlight-line={2}' --preview-window='~3,+{2}+3/4' \
-		--bind 'enter:become(micro -parsecursor=true {1}:{2}:{3})'
+		--bind 'enter:become(command "$EDITOR" {1}:{2}:{3})'

--- a/pkgs/wait-and-squashmerge/default.nix
+++ b/pkgs/wait-and-squashmerge/default.nix
@@ -2,8 +2,5 @@
 pkgs.writeShellApplication rec {
   name = "wait-and-squashmerge";
   text = builtins.readFile ./${name}.bash;
-  runtimeInputs = with pkgs; [
-    gh
-    micro
-  ];
+  runtimeInputs = with pkgs; [ gh ];
 }

--- a/pkgs/wait-and-squashmerge/wait-and-squashmerge.bash
+++ b/pkgs/wait-and-squashmerge/wait-and-squashmerge.bash
@@ -1,5 +1,5 @@
 readonly pr_number="$1"
-commit_subject="$(gh pr view "$pr_number" --json title --template '{{ .title }}' | micro)"
+commit_subject="$(gh pr view "$pr_number" --json title --template '{{ .title }}' | command "$EDITOR")"
 readonly commit_subject
 
 gh pr checks "$pr_number" --interval 5 --watch --fail-fast &&

--- a/windows/winget/winget-pkgs-basic.json
+++ b/windows/winget/winget-pkgs-basic.json
@@ -38,6 +38,9 @@
           "PackageIdentifier": "sharkdp.bat"
         },
         {
+          "PackageIdentifier": "Helix.Helix"
+        },
+        {
           "PackageIdentifier": "zyedidia.micro"
         },
         {


### PR DESCRIPTION
- Windows configuration is not yet shared with Linux
- Enable zellij keybindings by default again
- Refine hardcoded micro editor dependent packages with $EDITOR
- This PR will relate to GH-740
