### PR TITLE
Disable capslock with udev

### DIFF
--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -6,7 +6,8 @@
     # Specify hardware names even if `evdev:input:*` working for mostcase
     extraHwdb = ''
       evdev:name:Topre REALFORCE 87 US:*
-        KEYBOARD_KEY_70039=leftctrl # original: capslock
+        # original: capslock
+        KEYBOARD_KEY_70039=leftctrl
     '';
   };
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -15,8 +15,15 @@
   # Settings keyremap in raw layer than X. See GH-784
   # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
   # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
+  #
+  # Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
+  # How to get the KEYBOARD_KEY_700??: `showkey --scancodes` in VT
+  # How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
   environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
     evdev:name:Topre REALFORCE 87 US:*
       KEYBOARD_KEY_70039=leftctrl # original: capslock
+
+    evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # JIS
+      KEYBOARD_KEY_7003a=leftctrl # original: capslock
   '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,0 +1,12 @@
+{ ... }:
+{
+  services.udev = {
+    # Settings keyremap in raw layer than X. See GH-784
+    #
+    # Specify hardware names even if `evdev:input:*` working for mostcase
+    extraHwdb = ''
+      evdev:input:Topre REALFORCE 87 US:*
+        KEYBOARD_KEY_70039=leftctrl # original: capslock
+    '';
+  };
+}

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,6 +1,7 @@
 { ... }:
 {
   services.udev = {
+    enable = true;
     # Settings keyremap in raw layer than X. See GH-784
     #
     # Specify hardware names even if `evdev:input:*` working for mostcase

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -24,7 +24,7 @@
     evdev:name:Topre REALFORCE 87 US:*
       KEYBOARD_KEY_70039=leftctrl # original: capslock
 
-    evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # JIS
-      KEYBOARD_KEY_70039=leftctrl # original: capslock
+    evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # Both US and JIS have same name
+      KEYBOARD_KEY_70039=leftctrl # original: capslock, Both US and JIS have same keycode for capslock
   '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,22 +1,21 @@
 { ... }:
 {
-  # services.udev = {
-  #   enable = true;
-  #   # Settings keyremap in raw layer than X. See GH-784
+  services.udev = {
+    enable = true;
+    # Settings keyremap in raw layer than X. See GH-784
 
-  #   # Specify hardware names even if `evdev:input:*` working for mostcase
-  #   extraHwdb = ''
-  #     evdev:name:Topre REALFORCE 87 US:*
-  #       # original: capslock
-  #       KEYBOARD_KEY_70039=leftctrl
-  #   '';
-  # };
+    # Specify hardware names even if `evdev:input:*` working for mostcase
+    extraHwdb = ''
+      evdev:name:Topre REALFORCE 87 US:*
+        KEYBOARD_KEY_70039=leftctrl # original: capslock
+    '';
+  };
 
   # Settings keyremap in raw layer than X. See GH-784
   # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
   # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
-  environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
-    evdev:name:Topre REALFORCE 87 US:*
-      KEYBOARD_KEY_70039=leftctrl # original: capslock
-  '';
+  # environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
+  #   evdev:name:Topre REALFORCE 87 US:*
+  #     KEYBOARD_KEY_70039=leftctrl # original: capslock
+  # '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,21 +1,22 @@
 { ... }:
 {
-  services.udev = {
-    enable = true;
-    # Settings keyremap in raw layer than X. See GH-784
+  # services.udev = {
+  #   enable = true;
+  #   # Settings keyremap in raw layer than X. See GH-784
 
-    # Specify hardware names even if `evdev:input:*` working for mostcase
-    extraHwdb = ''
-      evdev:name:Topre REALFORCE 87 US:*
-        KEYBOARD_KEY_70039=leftctrl # original: capslock
-    '';
-  };
+  #   # Specify hardware names even if `evdev:input:*` working for mostcase
+  #   extraHwdb = ''
+  #     evdev:name:Topre REALFORCE 87 US:*
+  #       # original: capslock
+  #       KEYBOARD_KEY_70039=leftctrl
+  #   '';
+  # };
 
   # Settings keyremap in raw layer than X. See GH-784
   # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
   # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
-  # environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
-  #   evdev:name:Topre REALFORCE 87 US:*
-  #     KEYBOARD_KEY_70039=leftctrl # original: capslock
-  # '';
+  environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
+    evdev:name:Topre REALFORCE 87 US:*
+      KEYBOARD_KEY_70039=leftctrl # original: capslock
+  '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,14 +1,23 @@
 { ... }:
 {
-  services.udev = {
-    enable = true;
-    # Settings keyremap in raw layer than X. See GH-784
-    #
-    # Specify hardware names even if `evdev:input:*` working for mostcase
-    extraHwdb = ''
-      evdev:name:Topre REALFORCE 87 US:*
-        # original: capslock
-        KEYBOARD_KEY_70039=leftctrl
-    '';
-  };
+  # services.udev = {
+  #   enable = true;
+  #   # Settings keyremap in raw layer than X. See GH-784
+
+  #   # Specify hardware names even if `evdev:input:*` working for mostcase
+  #   extraHwdb = ''
+  #     evdev:name:Topre REALFORCE 87 US:*
+  #       # original: capslock
+  #       KEYBOARD_KEY_70039=leftctrl
+  #   '';
+  # };
+
+  # Settings keyremap in raw layer than X. See GH-784
+  # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
+  # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
+  environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
+    evdev:name:Topre REALFORCE 87 US:*
+      # original: capslock
+      KEYBOARD_KEY_70039=leftctrl
+  '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -25,6 +25,6 @@
       KEYBOARD_KEY_70039=leftctrl # original: capslock
 
     evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # JIS
-      KEYBOARD_KEY_7003a=leftctrl # original: capslock
+      KEYBOARD_KEY_70039=leftctrl # original: capslock
   '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -17,7 +17,6 @@
   # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
   environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
     evdev:name:Topre REALFORCE 87 US:*
-      # original: capslock
-      KEYBOARD_KEY_70039=leftctrl
+      KEYBOARD_KEY_70039=leftctrl # original: capslock
   '';
 }

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -16,10 +16,10 @@
   # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
   # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
   #
-  # Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
-  # How to get the KEYBOARD_KEY_700??: `showkey --scancodes` in VT
-  # How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
-  # How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
+  # - Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
+  # - How to get the KEYBOARD_KEY_700??: `showkey --scancodes` in VT
+  # - How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
+  # - How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
   environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
     evdev:name:Topre REALFORCE 87 US:*
       KEYBOARD_KEY_70039=leftctrl # original: capslock

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -19,6 +19,7 @@
   # Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
   # How to get the KEYBOARD_KEY_700??: `showkey --scancodes` in VT
   # How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
+  # How to apply?: After nixos-rebuild switch `sudo udevadm hwdb --update && sudo udevadm trigger` # TODO: Rewrite with systemd-hwdb
   environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
     evdev:name:Topre REALFORCE 87 US:*
       KEYBOARD_KEY_70039=leftctrl # original: capslock

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -5,7 +5,7 @@
     #
     # Specify hardware names even if `evdev:input:*` working for mostcase
     extraHwdb = ''
-      evdev:input:Topre REALFORCE 87 US:*
+      evdev:name:Topre REALFORCE 87 US:*
         KEYBOARD_KEY_70039=leftctrl # original: capslock
     '';
   };

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -19,7 +19,7 @@
   # Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
   # How to get the KEYBOARD_KEY_700??: `showkey --scancodes` in VT
   # How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
-  # How to apply?: After nixos-rebuild switch `sudo udevadm hwdb --update && sudo udevadm trigger` # TODO: Rewrite with systemd-hwdb
+  # How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
   environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
     evdev:name:Topre REALFORCE 87 US:*
       KEYBOARD_KEY_70039=leftctrl # original: capslock

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ../../configuration.nix
     ../../gui.nix
+    ../../hardware.nix
 
     ./hardware-configuration.nix
 

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ../../configuration.nix
     ../../gui.nix
+    ../../hardware.nix
 
     ./hardware-configuration.nix
     ./fingerprint.nix

--- a/nixos/xremap.nix
+++ b/nixos/xremap.nix
@@ -23,7 +23,7 @@
         {
           name = "Global";
           remap = {
-            "CapsLock" = "Ctrl_L";
+            # "CapsLock" = "Ctrl_L"; # Avoid using xremap to kill capslock for stability. See GH-784
             "Alt_L" = {
               "held" = "Alt_L";
               "alone" = "Muhenkan";


### PR DESCRIPTION
- **Disable capslock remapper in xremap**
- **Disable capslock with udev only for "Topre REALFORCE 87 US"**

Fixes GH-784
