### PR TITLE
Fix to normalize repo name in getrepo

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -78,6 +78,20 @@ args = [
 ]
 
 [tasks.test-go]
+dependencies = [
+  'test-cmd',
+  'test-pkg-trim-github-user-prefix-for-reponame',
+]
+
+[tasks.test-cmd]
+command = 'go'
+args = [
+  'test',
+  './...',
+]
+
+[tasks.test-pkg-trim-github-user-prefix-for-reponame]
+cwd = "./pkgs/trim-github-user-prefix-for-reponame"
 command = 'go'
 args = [
   'test',

--- a/pkgs/trim-github-user-prefix-for-reponame/default.nix
+++ b/pkgs/trim-github-user-prefix-for-reponame/default.nix
@@ -3,7 +3,7 @@ pkgs.buildGo122Module rec {
   pname = "trim-github-user-prefix-for-reponame";
   version = "0.0.1";
   default = pname;
-  vendorHash = null;
+  vendorHash = "sha256-1wycFQdf6sudxnH10xNz1bppRDCQjCz33n+ugP74SdQ=";
   src = ./.;
 
   meta = {

--- a/pkgs/trim-github-user-prefix-for-reponame/go.mod
+++ b/pkgs/trim-github-user-prefix-for-reponame/go.mod
@@ -1,3 +1,5 @@
 module github.com/kachick/dotfiles/pkgs/trim-github-user-prefix-for-reponame
 
 go 1.22.6
+
+require github.com/google/go-cmp v0.6.0

--- a/pkgs/trim-github-user-prefix-for-reponame/go.sum
+++ b/pkgs/trim-github-user-prefix-for-reponame/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/pkgs/trim-github-user-prefix-for-reponame/main.go
+++ b/pkgs/trim-github-user-prefix-for-reponame/main.go
@@ -7,9 +7,14 @@ import (
 	"strings"
 )
 
+// Can't I use https://github.com/google/go-github or https://github.com/cli/cli for more robust feature?
+// They are looks depend on GitHub API, not only for string operations...
 func extractRepo(line string) string {
 	// Using Cut cannot handle `multiple sep as foo/bar/baz`, but I don't need to conisder it for `owner/repo` or `repo` patterns.
-	_, after, found := strings.Cut(line, "/")
+	base := strings.TrimPrefix(line, "git@github.com:")
+	base = strings.TrimPrefix(base, "https://github.com/")
+	base = strings.TrimSuffix(base, ".git")
+	_, after, found := strings.Cut(base, "/")
 	if found {
 		return after
 	} else {

--- a/pkgs/trim-github-user-prefix-for-reponame/main.go
+++ b/pkgs/trim-github-user-prefix-for-reponame/main.go
@@ -7,16 +7,20 @@ import (
 	"strings"
 )
 
+func extractRepo(line string) string {
+	// Using Cut cannot handle `multiple sep as foo/bar/baz`, but I don't need to conisder it for `owner/repo` or `repo` patterns.
+	_, after, found := strings.Cut(line, "/")
+	if found {
+		return after
+	} else {
+		return line
+	}
+}
+
 func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Using Cut cannot handle `multiple sep as foo/bar/baz`, but I don't need to conisder it for `owner/repo` or `repo` patterns.
-		_, after, found := strings.Cut(line, "/")
-		if found {
-			fmt.Println(after)
-		} else {
-			fmt.Println(line)
-		}
+		fmt.Println(extractRepo(line))
 	}
 }

--- a/pkgs/trim-github-user-prefix-for-reponame/main_test.go
+++ b/pkgs/trim-github-user-prefix-for-reponame/main_test.go
@@ -21,14 +21,14 @@ func TestExtractRepo(t *testing.T) {
 			input: "dotfiles",
 			repo:  "dotfiles",
 		},
-		// "SSH": {
-		// 	input: "git@github.com:kachick/dotfiles.git",
-		// 	repo:  "dotfiles",
-		// },
-		// "HTTPS": {
-		// 	input: "https://github.com/kachick/dotfiles.git",
-		// 	repo:  "dotfiles",
-		// },
+		"SSH": {
+			input: "git@github.com:kachick/dotfiles.git",
+			repo:  "dotfiles",
+		},
+		"HTTPS": {
+			input: "https://github.com/kachick/dotfiles.git",
+			repo:  "dotfiles",
+		},
 	}
 
 	for description, tc := range testCases {

--- a/pkgs/trim-github-user-prefix-for-reponame/main_test.go
+++ b/pkgs/trim-github-user-prefix-for-reponame/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractRepo(t *testing.T) {
+	type testCase struct {
+		input string
+		repo  string
+	}
+
+	testCases := map[string]testCase{
+		"owner/repo": {
+			input: "kachick/dotfiles",
+			repo:  "dotfiles",
+		},
+		"repo": {
+			input: "dotfiles",
+			repo:  "dotfiles",
+		},
+		// "SSH": {
+		// 	input: "git@github.com:kachick/dotfiles.git",
+		// 	repo:  "dotfiles",
+		// },
+		// "HTTPS": {
+		// 	input: "https://github.com/kachick/dotfiles.git",
+		// 	repo:  "dotfiles",
+		// },
+	}
+
+	for description, tc := range testCases {
+		t.Run(description, func(t *testing.T) {
+			if diff := cmp.Diff(tc.repo, extractRepo(tc.input)); diff != "" {
+				t.Errorf("wrong result: %s", diff)
+			}
+		})
+	}
+}

--- a/pkgs/trim-github-user-prefix-for-reponame/main_test.go
+++ b/pkgs/trim-github-user-prefix-for-reponame/main_test.go
@@ -29,6 +29,10 @@ func TestExtractRepo(t *testing.T) {
 			input: "https://github.com/kachick/dotfiles.git",
 			repo:  "dotfiles",
 		},
+		"Non Git URL": {
+			input: "https://github.com/kachick/dotfiles",
+			repo:  "dotfiles",
+		},
 	}
 
 	for description, tc := range testCases {


### PR DESCRIPTION
- **Add tests for go pkgs**
- **Trim excess prefix and suffix**
