### PR TITLE
Keep the udev key remapper on NixOS even after being rebooted

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,6 @@ List defined hostnames
 nix flake show 'github:kachick/dotfiles' --json | jq '.nixosConfigurations | keys[]'
 ```
 
-And you may need to manually update `/etc/udev/hwdb.bin` for remapping keyboards.\
-See [GH-801](https://github.com/kachick/dotfiles/issues/801) for detail.
-
-```bash
-sudo systemd-hwdb update && sudo udevadm trigger
-```
-
 This repository intentionally reverts the home-manager NixOS module.\
 So, you should activate the user dotfiles with standalone home-manager even though NixOS.
 
@@ -190,8 +183,7 @@ For NixOS
 
 ```bash
 sudo nixos-rebuild switch --flake ".#$(hostname)" --show-trace && \
-    sudo systemd-hwdb update && sudo udevadm trigger && \
-        makers apply 'kachick@desktop'
+    makers apply 'kachick@desktop'
 ```
 
 If you encounter any errors in the above steps, Check and update CI and [wiki](https://github.com/kachick/dotfiles/wiki).

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -7,7 +7,7 @@
     # -  Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
     # - How to get the KEYBOARD_KEY_700??: `evtest /dev/input/event??`
     # - How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
-    # - How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
+    # - How to apply?: Rebuild and reboot. Don't use `sudo systemd-hwdb update && sudo udevadm trigger` except debugging purpose.
     extraHwdb = lib.mkBefore ''
       evdev:name:Topre REALFORCE 87 US:*
         KEYBOARD_KEY_70039=leftctrl # original: capslock

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,29 +1,19 @@
-{ ... }:
+{ lib, ... }:
 {
-  # services.udev = {
-  #   enable = true;
-  #   # Settings keyremap in raw layer than X. See GH-784
+  services.udev = {
+    enable = true;
+    # Settings keyremap in raw layer than X. See GH-784
+    #
+    # -  Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
+    # - How to get the KEYBOARD_KEY_700??: `evtest /dev/input/event??`
+    # - How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
+    # - How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
+    extraHwdb = lib.mkBefore ''
+      evdev:name:Topre REALFORCE 87 US:*
+        KEYBOARD_KEY_70039=leftctrl # original: capslock
 
-  #   # Specify hardware names even if `evdev:input:*` working for mostcase
-  #   extraHwdb = ''
-  #     evdev:name:Topre REALFORCE 87 US:*
-  #       # original: capslock
-  #       KEYBOARD_KEY_70039=leftctrl
-  #   '';
-  # };
-
-  # Settings keyremap in raw layer than X. See GH-784
-  # Use another filename of "99-local.hwdb"", it is preserved for each host
-  #
-  # - Specify hardware names even if `evdev:input:*` working for mostcase. I should care both US and JIS layout
-  # - How to get the KEYBOARD_KEY_700??: `evtest /dev/input/event??`
-  # - How to get the hardware name:: `udevadm info --attribute-walk /dev/input/event?? | grep -F 'ATTRS{name}'`
-  # - How to apply?: After nixos-rebuild switch `sudo systemd-hwdb update && sudo udevadm trigger`
-  environment.etc."udev/hwdb.d/98-keyboards.hwdb".text = ''
-    evdev:name:Topre REALFORCE 87 US:*
-      KEYBOARD_KEY_70039=leftctrl # original: capslock
-
-    evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # Both US and JIS have same name
-      KEYBOARD_KEY_70039=leftctrl # original: capslock, Both US and JIS have same keycode for capslock
-  '';
+      evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # Both US and JIS have same name
+        KEYBOARD_KEY_70039=leftctrl # original: capslock, Both US and JIS have same keycode for capslock
+    '';
+  };
 }

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 {
   networking.hostName = "moss";
@@ -23,10 +23,7 @@
 
   services.xserver.videoDrivers = [ "amdgpu" ];
 
-  # Settings keyremap in raw layer than X. See GH-784
-  # Don't use `services.udev.extraHwdb`, it does not create the file at least in NixOS 24.05
-  # See https://github.com/NixOS/nixpkgs/issues/182966 for detail
-  environment.etc."udev/hwdb.d/99-local.hwdb".text = ''
+  services.udev.extraHwdb = lib.mkAfter ''
     evdev:name:AT Translated Set 2 keyboard:*
       KEYBOARD_KEY_3a=leftctrl # original: capslock
   '';


### PR DESCRIPTION
This change and rebooting looks fixes GH-801, tested on moss machine

I don't know why the file is not actually registered in there (But in hwdb.bin?)

```
> lat /etc/udev
0755 - 10-10 21:55 /etc/udev
0777 - 10-10 21:55 ├── rules.d -> /etc/static/udev/rules.d
0777 - 10-10 21:55 └── hwdb.bin -> /etc/static/udev/hwdb.bin
```