### PR TITLE
Switch back to ssh-agent from gpg-agent  with setting `$SSH_ASKPASS` which internally uses gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ Check [traps](./windows/Multi-booting.md)
    ```bash
    touch ~/.ssh/id_ed25519 && chmod 400 ~/.ssh/id_ed25519
    hx ~/.ssh/id_ed25519
-   gpg-connect-agent updatestartuptty /bye
    ssh-add ~/.ssh/id_ed25519
    ```
 

--- a/home-manager/gpg.nix
+++ b/home-manager/gpg.nix
@@ -38,7 +38,7 @@ in
 
     pinentryPackage = pkgs.pinentry-tty;
 
-    enableSshSupport = true;
+    enableSshSupport = false;
   };
 
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/gpg.nix

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -16,8 +16,7 @@ in
 # - id_*.pub: I CAN register them for different services.
 {
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/services/ssh-agent.nix
-  # Prefer gpg-agent for SSH agent role
-  services.ssh-agent.enable = false;
+  services.ssh-agent.enable = pkgs.stdenv.isLinux;
 
   home.sessionVariables = {
     # 'force' ignores $DISPLAY. 'prefer' is not enough

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ pkgs, config, ... }:
 
 let
   # SSH files cannot use XDG Base Directory.
@@ -18,6 +18,12 @@ in
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/services/ssh-agent.nix
   # Prefer gpg-agent for SSH agent role
   services.ssh-agent.enable = false;
+
+  home.sessionVariables = {
+    # 'force' ignores $DISPLAY. 'prefer' is not enough
+    SSH_ASKPASS_REQUIRE = "force";
+    SSH_ASKPASS = "${pkgs.lib.getExe pkgs.pass} show ssh-pass";
+  };
 
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/ssh.nix
   programs.ssh = {

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -21,7 +21,14 @@ in
   home.sessionVariables = {
     # 'force' ignores $DISPLAY. 'prefer' is not enough
     SSH_ASKPASS_REQUIRE = "force";
-    SSH_ASKPASS = "${pkgs.lib.getExe pkgs.pass} show ssh-pass";
+    SSH_ASKPASS = pkgs.lib.getExe (
+      pkgs.writeShellApplication {
+        name = "ssh-ask-pass";
+        text = "pass show ssh-pass";
+        meta.description = "GH-714. Required to be wrapped with one command because of SSH_ASKPASS does not accepts arguments.";
+        runtimeInputs = with pkgs; [ pass ];
+      }
+    );
   };
 
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/ssh.nix

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -25,7 +25,7 @@ in
       pkgs.writeShellApplication {
         name = "ssh-ask-pass";
         text = "pass show ssh-pass";
-        meta.description = "GH-714. Required to be wrapped with one command because of SSH_ASKPASS does not accepts arguments.";
+        meta.description = "GH-714. Required to be wrapped with one command because of SSH_ASKPASS does not accept arguments.";
         runtimeInputs = with pkgs; [ pass ];
       }
     );

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -140,10 +140,6 @@
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;
-  # programs.gnupg.agent = {
-  #   enable = true;
-  #   enableSSHSupport = true;
-  # };
 
   # List services that you want to enable:
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -85,7 +85,7 @@
       gnome-music # does not support flac by defaults
     ]);
 
-  # Recommended to be uninstalled by gnupg.
+  # Recommended to be uninstalled by gnupg. I prefer this way, even though disabling gpg-agent ssh integrations.
   # https://wiki.gnupg.org/GnomeKeyring
   #
   # And enabling this makes $SSH_AUTH_SOCK overriding even through enabled gpg-agent in home-manager


### PR DESCRIPTION
* Update how to realize https://github.com/kachick/dotfiles/issues/714 with partially reverting https://github.com/kachick/dotfiles/pull/814 with https://github.com/kachick/dotfiles/pull/817 direction
* Might be a preparation of GH-849

Since using gpg-agent, it does not remain and hard to handle SSH passphrase.
Instead of that, pass command internally uses gpg. It looks enough to me.