### PR TITLE
Make shorter prompt

### DIFF
--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -39,6 +39,11 @@ style = "blue"
 
 [direnv]
 disabled = false
+# https://github.com/direnv/direnv-logo/blob/0949c12bafa532da0b23482a1bb042cf41b654fc/direnv-logo.png
+symbol = '📁'
+loaded_msg = '🍃'
+unloaded_msg = '🍂'
+format = '[$symbol$loaded]($style)'
 
 [character]
 success_symbol = "[>](bold green)"
@@ -60,18 +65,9 @@ format = "[$branch]($style)"
 style = "242"
 
 [git_status]
-format = "[[(*$conflicted$untracked$modified$staged$renamed$deleted)](218) ($ahead_behind$stashed)]($style)"
 style = "cyan"
-conflicted = "​"
-untracked = "​"
-modified = "​"
-staged = "​"
-renamed = "​"
-deleted = "​"
-stashed = "≡"
 
 [git_state]
-format = '\([$state( $progress_current/$progress_total)]($style)\) '
 style = "bright-black"
 
 [cmd_duration]
@@ -91,3 +87,8 @@ disabled = false
 
 [os]
 disabled = false
+
+[nix_shell]
+# Set another character with NixOS and keep short
+symbol = '☃️ '
+format = '[$symbol]($style)'

--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -3,6 +3,8 @@
 format = """
 $username\
 $hostname\
+$os\
+$container\
 $shlvl\
 $directory\
 $git_branch\
@@ -18,8 +20,6 @@ $ruby\
 $python\
 $deno\
 $nodejs\
-$os\
-$container\
 $direnv\
 $nix_shell\
 $shell\
@@ -43,7 +43,7 @@ disabled = false
 symbol = '📁'
 loaded_msg = '🍃'
 unloaded_msg = '🍂'
-format = '[$symbol$loaded]($style)'
+format = '[$symbol$loaded]($style) '
 
 [character]
 success_symbol = "[>](bold green)"
@@ -74,10 +74,6 @@ style = "bright-black"
 format = "[$duration]($style) "
 style = "yellow"
 
-[python]
-format = "[$virtualenv]($style) "
-style = "bright-black"
-
 [shell]
 disabled = false
 bash_indicator = 'bash'
@@ -91,4 +87,4 @@ disabled = false
 [nix_shell]
 # Set another character with NixOS and keep short
 symbol = '☃️ '
-format = '[$symbol]($style)'
+format = '[$symbol]($style) '

--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -9,7 +9,6 @@ $git_branch\
 $git_commit\
 $git_state\
 $git_status\
-$direnv\
 $crystal\
 $elm\
 $haskell\
@@ -19,12 +18,14 @@ $ruby\
 $python\
 $deno\
 $nodejs\
-$cmd_duration\
 $os\
 $container\
+$direnv\
 $nix_shell\
 $shell\
+$jobs\
 $time\
+$cmd_duration\
 $status\
 $line_break\
 $character"""


### PR DESCRIPTION
- **Adjust order of prompt attrs**
- **Adjust starship prompt to make shorter direnv and nix-shell indicators**
- **Adjsut order and spacing**

Keep shorter for tilling windows in laptop
