### PR TITLE
Make .viminfo respect XDG Base Directory

### DIFF
--- a/home-manager/vim.nix
+++ b/home-manager/vim.nix
@@ -6,7 +6,8 @@
 }:
 
 {
-  xdg.stateFile."vim/.keep".text = "Keep this directory because of home-manager and vim does not create the file if directory is missing";
+  # TODO: Prefer xdg.stateFile since home-manager release-24.11. See https://github.com/nix-community/home-manager/pull/5779
+  home.file."${config.xdg.stateHome}/vim/.keep".text = "Keep this directory because of home-manager and vim does not create the file if directory is missing";
 
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/vim.nix
   # https://nixos.wiki/wiki/Vim

--- a/home-manager/vim.nix
+++ b/home-manager/vim.nix
@@ -6,6 +6,8 @@
 }:
 
 {
+  xdg.stateFile."vim/.keep".text = "Keep this directory because of home-manager and vim does not create the file if directory is missing";
+
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/vim.nix
   # https://nixos.wiki/wiki/Vim
   programs.vim = {

--- a/home-manager/vim.nix
+++ b/home-manager/vim.nix
@@ -1,4 +1,9 @@
-{ pkgs, homemade-pkgs, ... }:
+{
+  pkgs,
+  config,
+  homemade-pkgs,
+  ...
+}:
 
 {
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/programs/vim.nix
@@ -20,6 +25,7 @@
     extraConfig = ''
       colorscheme iceberg
       set termguicolors
+      set viminfofile=${config.xdg.stateHome}/vim/viminfo
     '';
   };
 }


### PR DESCRIPTION
- **Make .viminfo respect XDG Base Directory**
- **Ensure to put vim directory in statehome**
- **Fix with avoiding missing xdg.stateHome**

Fixes https://github.com/kachick/dotfiles/issues/871