### PR TITLE
Ensure to set the wakeup flag in a NixOS desktop which is using USB inputs

### DIFF
--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -21,4 +21,14 @@
   };
 
   services.xserver.videoDrivers = [ "amdgpu" ];
+
+  powerManagement = {
+    enable = true;
+
+    # Prevent GH-894
+    powerDownCommands = ''
+      echo 'enabled' > '/sys/bus/usb/devices/usb3/power/wakeup'
+    '';
+  };
+
 }


### PR DESCRIPTION
Fixes GH-894

https://askubuntu.com/questions/848698/wake-up-from-suspend-using-usb-device#comment2435881_848699

Simple solution does not fix my problem. I'm using a USB KVM. And this code does not work after disconnect and reconnect.
