### PR TITLE
Make macOS only depend on free nixpkgs again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,42 +207,21 @@
             };
           };
 
-          x86-macOS =
-            let
-              system = "x86_64-darwin";
-            in
-            {
-              pkgs = nixpkgs.legacyPackages.${system};
-              extraSpecialArgs = {
-                homemade-pkgs = homemade-packages.${system};
-                edge-pkgs = import edge-nixpkgs {
-                  inherit system;
-                  config = {
-                    # Atleast required for following
-                    # signal-desktop: https://github.com/NixOS/nixpkgs/pull/348165/files#diff-05921dc46b537c59c8a76dfc3c3e9a3a1fd93345ee5bff8573aae36dedf719bcR49
-                    # android-studio: https://github.com/NixOS/nixpkgs/blob/3490095db7c455272ee96c1d99d424d029bdf576/pkgs/applications/editors/android-studio/common.nix#L281
-                    allowUnfree = true;
-                  };
-                };
-              };
+          x86-macOS = {
+            pkgs = nixpkgs.legacyPackages.x86_64-darwin;
+            extraSpecialArgs = {
+              homemade-pkgs = homemade-packages.x86_64-darwin;
+              edge-pkgs = edge-nixpkgs.legacyPackages.x86_64-darwin;
             };
+          };
 
-          aarch64-macOS =
-            let
-              system = "aarch64-darwin";
-            in
-            {
-              pkgs = nixpkgs.legacyPackages.${system};
-              extraSpecialArgs = {
-                homemade-pkgs = homemade-packages.${system};
-                edge-pkgs = import edge-nixpkgs {
-                  inherit system;
-                  config = {
-                    allowUnfree = true;
-                  };
-                };
-              };
+          aarch64-macOS = {
+            pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+            extraSpecialArgs = {
+              homemade-pkgs = homemade-packages.aarch64-darwin;
+              edge-pkgs = edge-nixpkgs.legacyPackages.aarch64-darwin;
             };
+          };
         in
         {
           "kachick@desktop" = home-manager.lib.homeManagerConfiguration (

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -12,12 +12,10 @@ lib.mkMerge [
   (lib.mkIf pkgs.stdenv.isDarwin {
     home = {
       sessionVariables = {
-        # ## If you prefer zed
-        #   * Do not specify Nix store path for zed in macOS
-        #     https://github.com/NixOS/nixpkgs/blob/bba8dffd3135f35810e9112c40ee621f4ede7cca/pkgs/by-name/ze/zed-editor/package.nix#L217-L219
-        #   * `cli: install` action installs into this path in macOS
-        # VISUAL = "zed --wait";
-        VISUAL = lib.getExe edge-pkgs.vscode;
+        # * Do not specify Nix store path for zed in macOS
+        #   https://github.com/NixOS/nixpkgs/blob/bba8dffd3135f35810e9112c40ee621f4ede7cca/pkgs/by-name/ze/zed-editor/package.nix#L217-L219
+        # * `cli: install` action installs into this path in macOS
+        VISUAL = "zed --wait";
 
         BROWSER = "open";
       };
@@ -56,8 +54,6 @@ lib.mkMerge [
         # edge-pkgs.zed-editor
 
         edge-pkgs.podman-desktop # Useable since https://github.com/NixOS/nixpkgs/pull/343648
-
-        edge-pkgs.vscode # Keep latest as possible
 
         edge-pkgs.signal-desktop # Useable since https://github.com/NixOS/nixpkgs/pull/348165
 

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -55,8 +55,6 @@ lib.mkMerge [
 
         edge-pkgs.podman-desktop # Useable since https://github.com/NixOS/nixpkgs/pull/343648
 
-        edge-pkgs.signal-desktop # Useable since https://github.com/NixOS/nixpkgs/pull/348165
-
         homemade-pkgs.maccy
       ];
     };

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -12,10 +12,11 @@ lib.mkMerge [
   (lib.mkIf pkgs.stdenv.isDarwin {
     home = {
       sessionVariables = {
-        # * Do not specify Nix store path for zed in macOS
-        #   https://github.com/NixOS/nixpkgs/blob/bba8dffd3135f35810e9112c40ee621f4ede7cca/pkgs/by-name/ze/zed-editor/package.nix#L217-L219
+        # * Do not specify Nix store path for zed and vscode in macOS
+        #   * zed is broken https://github.com/NixOS/nixpkgs/blob/bba8dffd3135f35810e9112c40ee621f4ede7cca/pkgs/by-name/ze/zed-editor/package.nix#L217-L219
+        #   * vscode is unfree and heavy when no binary cache
         # * `cli: install` action installs into this path in macOS
-        VISUAL = "zed --wait";
+        VISUAL = "code --wait";
 
         BROWSER = "open";
       };


### PR DESCRIPTION
- **Revert "Install vscode in macOS via nixpkgs (#882)"**
- **Revert "Install signal-desktop in macOS via nixpkgs (#861)"**
- **Make vscode as the default editor in macOS again**

Closes GH-885
Update, but keeps GH-754
Update GH-884
Reduce struggle around .github/workflows/cleanup-caches.yml

I can choose this way since macOS is not the preferred device

And I'm afraid, https://github.com/kachick/dotfiles/issues/243 might contain the unfree files (nevertheless it cannot be downloaded from other users?) 
