### PR TITLE
Extract linux only completions from zsh

### DIFF
--- a/home-manager/bash.nix
+++ b/home-manager/bash.nix
@@ -4,7 +4,6 @@
   pkgs,
   ...
 }:
-
 {
   services.gpg-agent.enableBashIntegration = true;
   programs.starship.enableBashIntegration = true;
@@ -119,8 +118,6 @@
         starship_precmd_user_func="set_win_title"
 
         source "${pkgs.fzf-git-sh}/share/fzf-git-sh/fzf-git.sh"
-        source "${pkgs.podman}/share/bash-completion/completions/podman"
-        source "${pkgs.kubectl}/share/bash-completion/completions/kubectl.bash"
         source "${pkgs.zellij}/share/bash-completion/completions/zellij.bash"
 
         # https://github.com/NixOS/nixpkgs/pull/362139

--- a/home-manager/linux.nix
+++ b/home-manager/linux.nix
@@ -51,6 +51,18 @@
       ]);
   };
 
+  programs = {
+    bash.initExtra = ''
+      source "${pkgs.podman}/share/bash-completion/completions/podman"
+      source "${pkgs.kubectl}/share/bash-completion/completions/kubectl.bash"
+    '';
+
+    zsh.initExtra = ''
+      source "${pkgs.podman}/share/zsh/site-functions/_podman"
+      source "${pkgs.kubectl}/share/zsh/site-functions/_kubectl"
+    '';
+  };
+
   # xdg-user-dirs NixOS module does not work or is not enough for me to keep English dirs even in Japanese locale.
   # Check your `~/.config/user-dirs.dirs` if you faced any trouble
   # https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-user-dirs.nix

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -228,8 +228,6 @@ in
       precmd_functions+=(set_win_title)
 
       source "${pkgs.fzf-git-sh}/share/fzf-git-sh/fzf-git.sh"
-      source "${pkgs.podman}/share/zsh/site-functions/_podman"
-      source "${pkgs.kubectl}/share/zsh/site-functions/_kubectl"
       # https://github.com/NixOS/nixpkgs/pull/362139
       source "${pkgs.unstable.dprint}/share/zsh/site-functions/_dprint"
       # cargo-make recommends to use bash completions for zsh


### PR DESCRIPTION
Follow GH-913

I noticed this task when addressing GH-916

However I may omit for now from the maintenance cost and optimization

- [x] zsh
- [ ] bash
- ~[ ] fish - https://github.com/kachick/dotfiles/pull/926~
