### PR TITLE
Uninstall signal-desktop

### DIFF
--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -158,22 +158,6 @@
 
       calibre
 
-      # TODO: Add `"--wayland-text-input-version=3"` after signal-desktop updates the Electron to 33.0.0 or higher. See GH-689 for detail.
-      # Don't use unstable channel. It frequently backported to stable channel
-      #   - https://github.com/NixOS/nixpkgs/commits/nixos-24.05/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
-      (signal-desktop.overrideAttrs (prev: {
-        preFixup =
-          prev.preFixup
-          + ''
-            gappsWrapperArgs+=(
-              --add-flags "--enable-features=UseOzonePlatform"
-              --add-flags "--ozone-platform=wayland"
-              --add-flags "--enable-wayland-ime"
-              --add-flags "--disable-features=WaylandFractionalScaleV1"
-            )
-          '';
-      }))
-
       gnome.dconf-editor
       gnome.gnome-boxes
 

--- a/windows/winget/winget-pkgs-entertainment.json
+++ b/windows/winget/winget-pkgs-entertainment.json
@@ -9,9 +9,6 @@
         },
         {
           "PackageIdentifier": "TrackerSoftware.PDF-XChangeEditor"
-        },
-        {
-          "PackageIdentifier": "OpenWhisperSystems.Signal"
         }
       ],
       "SourceDetails": {


### PR DESCRIPTION
Fix broken NixOS desktop. Fixes GH-928

I chose Signal with the cross platform features. So keeping only in Windows does not make sense.

I may dig another tool for that purpose.
