### PR TITLE
Fix `bash: warning: setlocale: LC_TIME: cannot change locale (en_DK.UTF-8): No such file or directory` for Non NixOS initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,6 @@ NixOS is often difficult for beginners like me. So I also use [Lima](#lima) for 
    Candidates
    - `user@linux-cli` # Used in container
 
-1. If you faced to lcoale errors such as `-bash: warning: setlocale: LC_TIME: cannot change locale (en_DK.UTF-8): No such file or directory`
-
-   ```bash
-   sudo localedef -f UTF-8 -i en_DK en_DK.UTF-8
-   ```
-
 ### Podman on Ubuntu
 
 1. Install uidmap without Nix for use of podman even if the podman will be installed from nixpkgs

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -75,6 +75,17 @@
       inherit homemade-pkgs;
     };
 
+    # https://github.com/NixOS/nixpkgs/blob/fe0ab2747612f6df8091438bb3bac0fcee942853/doc/packages/locales.section.md?plain=1#L5C223-L5C237
+    # https://github.com/nix-community/home-manager/blob/60bb110917844d354f3c18e05450606a435d2d10/modules/config/i18n.nix#L40-L63
+    i18n.glibcLocales = pkgs.glibcLocales.override {
+      allLocales = false;
+      locales = [
+        "en_US.UTF-8/UTF-8"
+        "en_DK.UTF-8/UTF-8"
+        "ja_JP.UTF-8/UTF-8"
+      ];
+    };
+
     # You can check the candidates in `locale -a`
     # pkgs.glibc installs many candidates, but it does not support darwin
     # https://wiki.archlinux.jp/index.php/%E3%83%AD%E3%82%B1%E3%83%BC%E3%83%AB

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -27,6 +27,17 @@
   # https://github.com/nix-community/home-manager/blob/release-24.05/modules/misc/xdg.nix
   xdg.enable = true;
 
+  # https://github.com/NixOS/nixpkgs/blob/fe0ab2747612f6df8091438bb3bac0fcee942853/doc/packages/locales.section.md?plain=1#L5C223-L5C237
+  # https://github.com/nix-community/home-manager/blob/60bb110917844d354f3c18e05450606a435d2d10/modules/config/i18n.nix#L40-L63
+  i18n.glibcLocales = pkgs.glibcLocales.override {
+    allLocales = false;
+    locales = [
+      "en_US.UTF-8/UTF-8"
+      "en_DK.UTF-8/UTF-8"
+      "ja_JP.UTF-8/UTF-8"
+    ];
+  };
+
   home = {
     # This value determines the Home Manager release that your
     # configuration is compatible with. This helps avoid breakage
@@ -73,17 +84,6 @@
       inherit pkgs;
       inherit edge-pkgs;
       inherit homemade-pkgs;
-    };
-
-    # https://github.com/NixOS/nixpkgs/blob/fe0ab2747612f6df8091438bb3bac0fcee942853/doc/packages/locales.section.md?plain=1#L5C223-L5C237
-    # https://github.com/nix-community/home-manager/blob/60bb110917844d354f3c18e05450606a435d2d10/modules/config/i18n.nix#L40-L63
-    i18n.glibcLocales = pkgs.glibcLocales.override {
-      allLocales = false;
-      locales = [
-        "en_US.UTF-8/UTF-8"
-        "en_DK.UTF-8/UTF-8"
-        "ja_JP.UTF-8/UTF-8"
-      ];
     };
 
     # You can check the candidates in `locale -a`


### PR DESCRIPTION
Why are containers working? Happened in lima

Only occurred in `bash -l` step