### PR TITLE
Make it possible to use Epson printer and the bundled scanner in NixOS

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -60,9 +60,6 @@
     enable = true;
   };
 
-  # Enable CUPS to print documents.
-  services.printing.enable = true;
-
   hardware.bluetooth.enable = true; # enables support for Bluetooth
   hardware.bluetooth.powerOnBoot = true; # powers up the default Bluetooth controller on boot
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -25,6 +25,8 @@
         "wheel"
         "input" # For finger print in GDM
         "libvirtd" # For virt-manager
+        "scanner"
+        "lp" # For scanner
       ];
       packages = [
         # Don't install spotify, it does not activate IME and no binary cache with the unfree license.
@@ -61,7 +63,10 @@
     };
   };
 
-  services.udev.packages = with pkgs; [ gnome.gnome-settings-daemon ];
+  services.udev.packages = with pkgs; [
+    gnome.gnome-settings-daemon
+    sane-airscan
+  ];
 
   # To avoid unexpected overriding with the NixOS module. I prefer gpg-agent or another way for that.
   programs.ssh.enableAskPassword = false;

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -112,6 +112,17 @@
 
   services.blueman.enable = true;
 
+  services.printing = {
+    enable = true;
+    drivers = [ pkgs.epson-escpr ];
+  };
+
+  # To setup a wireless printer
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true;
+  };
+
   environment.systemPackages =
     [
       # version in nixos-24.05 does not enable IME

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   services.udev = {
     enable = true;
@@ -15,5 +15,12 @@
       evdev:name:Lenovo ThinkPad Compact USB Keyboard with TrackPoint:* # Both US and JIS have same name
         KEYBOARD_KEY_70039=leftctrl # original: capslock, Both US and JIS have same keycode for capslock
     '';
+  };
+
+  # http://www.sane-project.org/sane-mfgs.html#Z-EPSON
+  # Apple AirScan supported devices: https://support.apple.com/ja-jp/HT201311
+  hardware.sane = {
+    enable = true;
+    extraBackends = [ pkgs.sane-airscan ];
   };
 }


### PR DESCRIPTION
Fixes GH-816

* [x] Printer
* [x] Scanner - Driver less, and no Epson bundled OCR. However works as a MVP :tada: 
