### PR TITLE
Suppress `Unsupported option "gssapiauthentication"` waning with lima generated ssh config in NixOS 24.11

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -29,6 +29,13 @@
               url = "https://github.com/lima-vm/lima/commit/071c3d7ab33237610eed0311249308b169f5ca5f.patch";
               hash = "sha256-bCHZv1qctr39PTRJ60SPnXLArXGl4/FV45G+5nDxMFY=";
             })
+
+            (prev.fetchpatch {
+              # https://github.com/kachick/lima/pull/1
+              name = "lima-suppress-gssapi-warning.patch";
+              url = "https://patch-diff.githubusercontent.com/raw/kachick/lima/pull/1.patch";
+              hash = prev.lib.fakeHash;
+            })
           ];
         }
       else

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -34,7 +34,7 @@
               # https://github.com/kachick/lima/pull/1
               name = "lima-suppress-gssapi-warning.patch";
               url = "https://patch-diff.githubusercontent.com/raw/kachick/lima/pull/1.patch";
-              hash = prev.lib.fakeHash;
+              hash = "sha256-QTEYorN+nj66WMlMz+hsoZUWPnlGPDCw0VSsqsiayls=";
             })
           ];
         }


### PR DESCRIPTION
Apply https://github.com/kachick/lima/pull/1 and Fixes GH-950

Fixed except build time... :joy: (Want https://github.com/kachick/dotfiles/issues/754)