### PR TITLE
Introduce memreserver to fix unrecoverable suspend on NixOS 24.11 and AMD APU

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
           pkgs = mkPkgs system;
         in
         {
+          memreserver = pkgs.my.memreserver;
           cozette = pkgs.my.cozette;
           micro-kdl = pkgs.my.micro-kdl;
           micro-nordcolors = pkgs.my.micro-nordcolors;

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -11,6 +11,7 @@
 {
   imports = [
     (import ./console.nix { inherit pkgs; })
+    ./modules/hardware/memreserver.nix
   ];
 
   nix.settings.experimental-features = [

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -37,4 +37,7 @@
     # Enable keyboard - "ThinkPad Compact USB Keyboard with TrackPoint" wakeup
     ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6047", ATTR{power/wakeup}="enabled"
   '';
+
+  # GH-959
+  hardware.memreserver.enable = true;
 }

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -27,4 +27,7 @@
     evdev:name:AT Translated Set 2 keyboard:*
       KEYBOARD_KEY_3a=leftctrl # original: capslock
   '';
+
+  # GH-959
+  hardware.memreserver.enable = true;
 }

--- a/nixos/modules/hardware/memreserver.nix
+++ b/nixos/modules/hardware/memreserver.nix
@@ -1,0 +1,36 @@
+# Imported from https://github.com/NixOS/nixpkgs/pull/225819 to fix GH-959
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+{
+  options = {
+    hardware.memreserver = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc ''
+          Enable memreserver sleep hook.
+          Makes sure that GPUs with dedicated VRAM can suspend correctly.
+        '';
+      };
+    };
+  };
+
+  config = mkIf config.hardware.memreserver.enable {
+    systemd.services.memreserver = {
+      description = "Sleep hook which frees up RAM needed to evacuate GPU VRAM into";
+      before = [ "sleep.target" ];
+      wantedBy = [ "sleep.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.my.memreserver}/bin/memreserver";
+      };
+    };
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -64,4 +64,6 @@
   git-resolve-conflict = pkgs.callPackage ./git-resolve-conflict { };
   renmark = pkgs.callPackage ./renmark { };
   preview = pkgs.callPackage ./preview { };
+
+  memreserver = pkgs.callPackage ./memreserver { };
 }

--- a/pkgs/memreserver/default.nix
+++ b/pkgs/memreserver/default.nix
@@ -1,0 +1,38 @@
+# Imported from https://github.com/NixOS/nixpkgs/pull/225819 to fix GH-959
+
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  libdrm,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "memreserver";
+  version = "unstable-2023-04-01";
+
+  src = fetchFromGitLab {
+    domain = "git.dolansoft.org";
+    owner = "lorenz";
+    repo = pname;
+    rev = "480253e565dab935df1d1c4e615ebc8a8dc81ba4";
+    hash = "sha256-HjcrH98hH2zKdsHolYCFugL39sT1VjroVhRf8a8dpIA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [ libdrm ];
+
+  meta = with lib; {
+    homepage = "https://git.dolansoft.org/lorenz/memreserver";
+    description = "Sleep hook which frees up RAM needed to evacuate GPU VRAM into";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lorenz ];
+  };
+}


### PR DESCRIPTION
Attempt to fix GH-959
