### PR TITLE
Integrate vscode + gnome-libsecret + pass(password-store) on NixOS

### DIFF
--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -26,4 +26,12 @@
       };
     };
   };
+
+  # Extracted from encryption.nix to avoid dbus error in GitHub hosted runner
+  #
+  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/pass-secret-service.nix
+  # Make it possible to use libsecret which is required in vscode GitHub authentication(--password-store="gnome-libsecret"), without gnome-keyring(GH-814).
+  #
+  # Alternative candidates: https://github.com/grimsteel/pass-secret-service
+  services.pass-secret-service.enable = true;
 }

--- a/home-manager/encryption.nix
+++ b/home-manager/encryption.nix
@@ -14,24 +14,23 @@ in
 {
   # Don't set $SEQUOIA_HOME, it unified config and data, cache to one directory as same as gpg era.
   # Use default $HOME instead, it respects XDG Base Directory Specification
-  services = {
-    # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/gpg-agent.nix
-    gpg-agent = {
-      enable = pkgs.stdenv.isLinux;
 
-      # Update [darwin.nix](darwin.nix) if changed this section
-      #
-      # https://superuser.com/questions/624343/keep-gnupg-credentials-cached-for-entire-user-session
-      defaultCacheTtl = day * 7;
-      # https://github.com/openbsd/src/blob/862f3f2587ccb85ac6d8602dd1601a861ae5a3e8/usr.bin/ssh/ssh-agent.1#L167-L173
-      # ssh-agent sets it as infinite by default. So I can relax here (maybe)
-      defaultCacheTtlSsh = day * 30;
-      maxCacheTtl = day * 7;
+  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/gpg-agent.nix
+  services.gpg-agent = {
+    enable = pkgs.stdenv.isLinux;
 
-      pinentryPackage = pkgs.pinentry-tty;
+    # Update [darwin.nix](darwin.nix) if changed this section
+    #
+    # https://superuser.com/questions/624343/keep-gnupg-credentials-cached-for-entire-user-session
+    defaultCacheTtl = day * 7;
+    # https://github.com/openbsd/src/blob/862f3f2587ccb85ac6d8602dd1601a861ae5a3e8/usr.bin/ssh/ssh-agent.1#L167-L173
+    # ssh-agent sets it as infinite by default. So I can relax here (maybe)
+    defaultCacheTtlSsh = day * 30;
+    maxCacheTtl = day * 7;
 
-      enableSshSupport = false;
-    };
+    pinentryPackage = pkgs.pinentry-tty;
+
+    enableSshSupport = false;
   };
 
   home.sessionVariables = rec {

--- a/home-manager/encryption.nix
+++ b/home-manager/encryption.nix
@@ -15,22 +15,30 @@ in
   # Don't set $SEQUOIA_HOME, it unified config and data, cache to one directory as same as gpg era.
   # Use default $HOME instead, it respects XDG Base Directory Specification
 
-  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/gpg-agent.nix
-  services.gpg-agent = {
-    enable = pkgs.stdenv.isLinux;
+  services = {
+    # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/gpg-agent.nix
+    gpg-agent = {
+      enable = pkgs.stdenv.isLinux;
 
-    # Update [darwin.nix](darwin.nix) if changed this section
+      # Update [darwin.nix](darwin.nix) if changed this section
+      #
+      # https://superuser.com/questions/624343/keep-gnupg-credentials-cached-for-entire-user-session
+      defaultCacheTtl = day * 7;
+      # https://github.com/openbsd/src/blob/862f3f2587ccb85ac6d8602dd1601a861ae5a3e8/usr.bin/ssh/ssh-agent.1#L167-L173
+      # ssh-agent sets it as infinite by default. So I can relax here (maybe)
+      defaultCacheTtlSsh = day * 30;
+      maxCacheTtl = day * 7;
+
+      pinentryPackage = pkgs.pinentry-tty;
+
+      enableSshSupport = false;
+    };
+
+    # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/pass-secret-service.nix
+    # Make it possible to use libsecret which is required in vscode GitHub authentication(--password-store="gnome-libsecret"), without gnome-keyring(GH-814).
     #
-    # https://superuser.com/questions/624343/keep-gnupg-credentials-cached-for-entire-user-session
-    defaultCacheTtl = day * 7;
-    # https://github.com/openbsd/src/blob/862f3f2587ccb85ac6d8602dd1601a861ae5a3e8/usr.bin/ssh/ssh-agent.1#L167-L173
-    # ssh-agent sets it as infinite by default. So I can relax here (maybe)
-    defaultCacheTtlSsh = day * 30;
-    maxCacheTtl = day * 7;
-
-    pinentryPackage = pkgs.pinentry-tty;
-
-    enableSshSupport = false;
+    # Alternative candidates: https://github.com/grimsteel/pass-secret-service
+    pass-secret-service.enable = pkgs.stdenv.isLinux;
   };
 
   home.sessionVariables = rec {

--- a/home-manager/encryption.nix
+++ b/home-manager/encryption.nix
@@ -14,7 +14,6 @@ in
 {
   # Don't set $SEQUOIA_HOME, it unified config and data, cache to one directory as same as gpg era.
   # Use default $HOME instead, it respects XDG Base Directory Specification
-
   services = {
     # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/gpg-agent.nix
     gpg-agent = {
@@ -33,12 +32,6 @@ in
 
       enableSshSupport = false;
     };
-
-    # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/pass-secret-service.nix
-    # Make it possible to use libsecret which is required in vscode GitHub authentication(--password-store="gnome-libsecret"), without gnome-keyring(GH-814).
-    #
-    # Alternative candidates: https://github.com/grimsteel/pass-secret-service
-    pass-secret-service.enable = pkgs.stdenv.isLinux;
   };
 
   home.sessionVariables = rec {

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -177,15 +177,24 @@
       # Don't use unstable channel. It frequently backported to stable channel
       #   - https://github.com/NixOS/nixpkgs/commits/nixos-24.11/pkgs/applications/editors/vscode/vscode.nix
       # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/applications/editors/vscode/generic.nix#L207-L217
-      (vscode.override {
-        # https://wiki.archlinux.org/title/Wayland#Electron
-        # https://github.com/NixOS/nixpkgs/blob/3f8b7310913d9e4805b7e20b2beabb27e333b31f/pkgs/applications/editors/vscode/generic.nix#L207-L214
-        commandLineArgs = [
-          "--enable-wayland-ime=true" # TODO: Remove after https://github.com/NixOS/nixpkgs/pull/361341 introduced. At least nixos-25.05
-          # TODO: Add `"--wayland-text-input-version=3"` after vscode updates the Electron to 33.0.0 or higher. See GH-689 for detail.
-          "--password-store=gnome-libsecret" # Required for GitHub Authentication. For example gnome-keyring, kwallet5, KeepassXC, pass-secret-service
-        ];
-      })
+      (
+        (vscode.override {
+          # https://wiki.archlinux.org/title/Wayland#Electron
+          # https://github.com/NixOS/nixpkgs/blob/3f8b7310913d9e4805b7e20b2beabb27e333b31f/pkgs/applications/editors/vscode/generic.nix#L207-L214
+          commandLineArgs = [
+            "--enable-wayland-ime=true" # TODO: Remove after https://github.com/NixOS/nixpkgs/pull/361341 introduced. At least nixos-25.05
+            # TODO: Add `"--wayland-text-input-version=3"` after vscode updates the Electron to 33.0.0 or higher. See GH-689 for detail.
+
+            # https://github.com/microsoft/vscode/blob/5655a12f6af53c80ac9a3ad085677d6724761cab/src/vs/platform/encryption/common/encryptionService.ts#L28-L71
+            # https://github.com/microsoft/vscode/blob/5655a12f6af53c80ac9a3ad085677d6724761cab/src/main.ts#L244-L253
+            "--password-store=gnome-libsecret" # Required for GitHub Authentication. For example gnome-keyring, kwallet5, KeepassXC, pass-secret-service
+          ];
+        }).overrideAttrs
+        (prevAttrs: {
+          # https://incipe.dev/blog/post/using-visual-studio-code-insiders-under-home-manager/#an-os-keyring-couldnt-be-identified-for-storing-the-encryption-related-data-in-your-current-desktop-environment
+          runtimeDependencies = prevAttrs.runtimeDependencies ++ [ pkgs.libsecret ];
+        })
+      )
 
       # NOTE: Google might extract chrome from themself with `Antitrust` penalties
       #       https://edition.cnn.com/2024/11/20/business/google-sell-chrome-justice-department/

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -183,6 +183,7 @@
         commandLineArgs = [
           "--enable-wayland-ime=true" # TODO: Remove after https://github.com/NixOS/nixpkgs/pull/361341 introduced. At least nixos-25.05
           # TODO: Add `"--wayland-text-input-version=3"` after vscode updates the Electron to 33.0.0 or higher. See GH-689 for detail.
+          "--password-store=gnome-libsecret" # Required for GitHub Authentication. For example gnome-keyring, kwallet5, KeepassXC, pass-secret-service
         ];
       })
 


### PR DESCRIPTION
- **Enable gnome-libsecret with pass(password-store) family**
- **Inject missing libsecret for vscode runtimeDependencies**

To realize GitHub authentication
