### PR TITLE
Make ghostty as the default terminal

### DIFF
--- a/config/ghostty/config.common
+++ b/config/ghostty/config.common
@@ -20,3 +20,7 @@ background-opacity = 0.85
 theme = ForestBlue
 # Avoid the ligatures in "JetBrains Mono" by default
 font-family = "PlemolJP Console NF"
+
+# ghostty documents said setting true by default in Linux but macOS disabled.
+# However it looks not enabled in Linux behaviors. And keeping same behaviors should be useful if I use same tool in multuple environments.
+copy-on-select = true

--- a/config/ghostty/config.common
+++ b/config/ghostty/config.common
@@ -18,3 +18,5 @@ background-opacity = 0.85
 # ghostty can set both dark and light. However always use dark for terminals
 # theme = dark:ForestBlue,light:iTerm2 Tango Light
 theme = ForestBlue
+# Avoid the ligatures in "JetBrains Mono" by default
+font-family = "PlemolJP Console NF"

--- a/config/ghostty/config.common
+++ b/config/ghostty/config.common
@@ -22,5 +22,6 @@ theme = ForestBlue
 font-family = "PlemolJP Console NF"
 
 # ghostty documents said setting true by default in Linux but macOS disabled.
-# However it looks not enabled in Linux behaviors. And keeping same behaviors should be useful if I use same tool in multuple environments.
-copy-on-select = true
+# However keeping same behaviors should be useful if I use same tool in multuple environments.
+# And just setting `true` did not work on my GNOME
+copy-on-select = clipboard

--- a/config/ghostty/config.common
+++ b/config/ghostty/config.common
@@ -3,9 +3,11 @@
 #   macOS: cmd+shift+,
 
 # See also 899be8e51cb288fe0ae91267f495ade7bfb80bc9
-# FIXME: ghostty 1.0.1 Looks not to disable the blinking even if setting both.
+# This disbling does not work on `nix run`. Installed in nixos and ran from launcher worked (from shell or gnome difference?.
 cursor-style-blink = false
+# See https://github.com/ghostty-org/ghostty/discussions/2812
 shell-integration-features = no-cursor
+cursor-style = bar
 
 # Looks not appeared in Linux. Why? However I can omit this trivial thing.
 background-opacity = 0.85

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -33,7 +33,6 @@
       pinentry_mac
 
       # alacritty # Don't install macOS alacritty with nixpkgs. Alacritty often changes schema and I'm negative to use latest until https://github.com/NixOS/nixpkgs/issues/107466
-      kitty
 
       # Don't install firefox via nixpkgs for darwin, it is broken https://github.com/NixOS/nixpkgs/blob/bac526a0fe6da6b10cfe2454f62a0defdbf1d898/pkgs/applications/networking/browsers/firefox/packages.nix#L23
 

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -34,7 +34,6 @@
 
       # alacritty # Don't install macOS alacritty with nixpkgs. Alacritty often changes schema and I'm negative to use latest until https://github.com/NixOS/nixpkgs/issues/107466
       kitty
-      # foot is only provided for Linux wayland
 
       # Don't install firefox via nixpkgs for darwin, it is broken https://github.com/NixOS/nixpkgs/blob/bac526a0fe6da6b10cfe2454f62a0defdbf1d898/pkgs/applications/networking/browsers/firefox/packages.nix#L23
 

--- a/home-manager/genericLinux.nix
+++ b/home-manager/genericLinux.nix
@@ -9,7 +9,7 @@
       # Make it possible to handle "xterm-kitty" in SSH remotes or lima guest VM with tiny filesize and setups. See GH-932
       #
       # Don't set this in NixOS desktop. It has own value.
-      TERMINFO_DIRS = "${pkgs.kitty.terminfo}/share/terminfo";
+      TERMINFO_DIRS = "${pkgs.kitty.terminfo}/share/terminfo:${pkgs.unstable.ghostty.terminfo}/share/terminfo";
     };
   };
 }

--- a/home-manager/genericLinux.nix
+++ b/home-manager/genericLinux.nix
@@ -6,9 +6,11 @@
 
   home = {
     sessionVariables = {
-      # Make it possible to handle "xterm-kitty" in SSH remotes or lima guest VM with tiny filesize and setups. See GH-932
+      # Make it possible to handle special terminfo such as "xterm-kitty" in SSH remotes or lima guest VM with tiny filesize and setups. See GH-932
       #
-      # Don't set this in NixOS desktop. It has own value.
+      # - Don't set this in NixOS desktop. It has own value
+      # - Don't include `pkgs.ANYTTY` to avoid the build and or download large package. Use `pkgs.ANYTTY.terminfo`
+      # - Don't remove termnfo even if it is outdated
       TERMINFO_DIRS = "${pkgs.kitty.terminfo}/share/terminfo:${pkgs.unstable.ghostty.terminfo}/share/terminfo";
     };
   };

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,6 +42,7 @@ in
 
         favorite-apps = [
           "kitty.desktop"
+          "com.mitchellh.ghostty.desktop"
           "dev.zed.Zed.desktop"
           "google-chrome.desktop"
           "podman-desktop.desktop"

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -40,8 +40,9 @@ in
           ]
         );
 
+        # Might be needed to reboot to enable icons
         favorite-apps = [
-          "com.mitchellh.ghostty.desktop" # FIXME: No icon
+          "com.mitchellh.ghostty.desktop"
           "dev.zed.Zed.desktop"
           "google-chrome.desktop"
           "podman-desktop.desktop"

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -41,8 +41,7 @@ in
         );
 
         favorite-apps = [
-          "kitty.desktop"
-          "com.mitchellh.ghostty.desktop"
+          "com.mitchellh.ghostty.desktop" # FIXME: No icon
           "dev.zed.Zed.desktop"
           "google-chrome.desktop"
           "podman-desktop.desktop"
@@ -55,7 +54,7 @@ in
 
       # https://unix.stackexchange.com/questions/481142/launch-default-terminal-emulator-by-command
       "org/gnome/desktop/default-applications/terminal" = {
-        exec = lib.getExe pkgs.kitty;
+        exec = lib.getExe pkgs.unstable.ghostty;
         # exec-arg="";
       };
 
@@ -154,7 +153,7 @@ in
       "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0" = {
         name = "Terminal";
         binding = "<Super>t";
-        command = lib.getExe pkgs.kitty;
+        command = lib.getExe pkgs.unstable.ghostty;
       };
 
       "org/gnome/shell/extensions/clipboard-history" = {

--- a/home-manager/terminals.nix
+++ b/home-manager/terminals.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 
 {
   xdg = {
@@ -18,28 +18,5 @@
         recursive = true;
       };
     };
-  };
-
-  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/programs/kitty.nix
-  programs.kitty = {
-    enable = true;
-    package = pkgs.emptyDirectory;
-    themeFile = "zenwritten_dark"; # basename in a file of https://github.com/kovidgoyal/kitty-themes/tree/master/themes
-    settings = {
-      shell = lib.getExe pkgs.zsh;
-      cursor_shape = "beam";
-      cursor_blink_interval = 0;
-      copy_on_select = "clipboard";
-      tab_bar_edge = "top";
-      # tab_bar_style = "separator";
-      # tab_separator = " | ";
-      tab_bar_style = "slant";
-    };
-
-    # Avoiding a home-manager definition bug for rejecting all float.
-    # https://github.com/nix-community/home-manager/issues/4850
-    extraConfig = ''
-      background_opacity 0.85
-    '';
   };
 }

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -143,7 +143,7 @@
 
       gdm-settings
 
-      # unstable.ghostty # TODO: Enable after introducing https://github.com/NixOS/nixpkgs/pull/368404
+      unstable.ghostty
 
       alacritty
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -132,8 +132,6 @@
       # https://github.com/NixOS/nixpkgs/issues/33282
       xdg-user-dirs
 
-      kitty
-
       cyme
       lshw
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -132,7 +132,6 @@
       # https://github.com/NixOS/nixpkgs/issues/33282
       xdg-user-dirs
 
-      foot
       kitty
 
       cyme


### PR DESCRIPTION
Follow https://github.com/kachick/dotfiles/pull/1004 with https://github.com/kachick/dotfiles/pull/1008 

- **Install ghostty which is useable since GH-1008**
- **Uninstall foot since using ghostty**
- **Add ghostty for GNOME dock**
- **Fix and add comments for ghostty cursor**
- **Add ghostty terminfo in containers and lima**
- **Avoid ghostty default font with the enabled ligatures**
- **Enable copy-on-select in ghostty**
- **Fix ghostty copy-on-select on NixOS**
- **Uninstall kitty except the terminfo**
