### PR TITLE
Fix gnome-online-accounts by enabling gnome-keyring and unsetting SSH_AUTH_SOCK

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,6 @@ user:password
 
 # reddit often rejects request from GitHub Actions
 www.reddit.com/
+
+# The server is unstable
+ubuntuforums.org

--- a/config/rclone.md
+++ b/config/rclone.md
@@ -1,7 +1,7 @@
 # Rclone
 
 Rclone enables an OSS vault on several Cloud Storages.\
-And it makes it possible to use [Google Drive on Linux](https://abevoelker.github.io/how-long-since-google-said-a-google-drive-linux-client-is-coming/).
+And it makes it possible to use [Google Drive on Linux](https://abevoelker.github.io/how-long-since-google-said-a-google-drive-linux-client-is-coming/) without gnome-online-accounts.
 
 ## Setup
 

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -26,12 +26,4 @@
       };
     };
   };
-
-  # Extracted from encryption.nix to avoid dbus error in GitHub hosted runner
-  #
-  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/services/pass-secret-service.nix
-  # Make it possible to use libsecret which is required in vscode GitHub authentication(--password-store="gnome-libsecret"), without gnome-keyring(GH-814).
-  #
-  # Alternative candidates: https://github.com/grimsteel/pass-secret-service
-  services.pass-secret-service.enable = true;
 }

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -102,7 +102,7 @@
   # https://github.com/NixOS/nixpkgs/issues/101616
   #
   # Using mkforce for https://discourse.nixos.org/t/gpg-smartcard-for-ssh/33689/3
-  services.gnome.gnome-keyring.enable = lib.mkForce false;
+  # services.gnome.gnome-keyring.enable = lib.mkForce false;
 
   # Enable touchpad support (enabled default in most desktopManager).
   services.libinput = {

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -101,9 +101,8 @@
   # Require mkforce if you want to disable. See https://discourse.nixos.org/t/gpg-smartcard-for-ssh/33689/3
   services.gnome.gnome-keyring.enable = true;
   # On the otherhand, I should avoid deprecated gnome-keyring for ssh integrations even if it looks working.
-  # gnome-keyring enables pam.sshAgentAuth, and it sets the $SSH_AUTH_SOCK, and following modules skips to override this variable. So I should stop the first flag here.
-  # This workaround might be updated with https://github.com/NixOS/nixpkgs/issues/140824
-  security.pam.sshAgentAuth.enable = lib.mkForce false; # Require mkforce if you want to disable.
+  # gnome-keyring enables pam.sshAgentAuth, and it sets the $SSH_AUTH_SOCK, and following modules skips to override this variable. But just disabling security.pam.sshAgentAuth does not resolve it. It should be done in package build phase.
+  # The workaround might be updated with https://github.com/NixOS/nixpkgs/issues/140824
 
   # Enable touchpad support (enabled default in most desktopManager).
   services.libinput = {

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -92,7 +92,6 @@
     evince # document viewer
     gnome-calendar
     gnome-music # does not support flac by defaults
-    gnome-online-accounts # See GH-1015
   ];
 
   # I need gnome-keyring to use gnome-online-accounts even though recommended to be uninstalled by gnupg. pass-secret families didn't work on goa. See GH-1034 and GH-1036

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -95,14 +95,15 @@
     gnome-online-accounts # See GH-1015
   ];
 
-  # Recommended to be uninstalled by gnupg. I prefer this way, even though disabling gpg-agent ssh integrations.
+  # I need gnome-keyring to use gnome-online-accounts even though recommended to be uninstalled by gnupg. pass-secret families didn't work on goa. See GH-1034 and GH-1036
   # https://wiki.gnupg.org/GnomeKeyring
   #
-  # And enabling this makes $SSH_AUTH_SOCK overriding even through enabled gpg-agent in home-manager
-  # https://github.com/NixOS/nixpkgs/issues/101616
-  #
-  # Using mkforce for https://discourse.nixos.org/t/gpg-smartcard-for-ssh/33689/3
-  # services.gnome.gnome-keyring.enable = lib.mkForce false;
+  # Require mkforce if you want to disable. See https://discourse.nixos.org/t/gpg-smartcard-for-ssh/33689/3
+  services.gnome.gnome-keyring.enable = true;
+  # On the otherhand, I should avoid deprecated gnome-keyring for ssh integrations even if it looks working.
+  # gnome-keyring enables pam.sshAgentAuth, and it sets the $SSH_AUTH_SOCK, and following modules skips to override this variable. So I should stop the first flag here.
+  # This workaround might be updated with https://github.com/NixOS/nixpkgs/issues/140824
+  security.pam.sshAgentAuth.enable = false;
 
   # Enable touchpad support (enabled default in most desktopManager).
   services.libinput = {

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -103,7 +103,7 @@
   # On the otherhand, I should avoid deprecated gnome-keyring for ssh integrations even if it looks working.
   # gnome-keyring enables pam.sshAgentAuth, and it sets the $SSH_AUTH_SOCK, and following modules skips to override this variable. So I should stop the first flag here.
   # This workaround might be updated with https://github.com/NixOS/nixpkgs/issues/140824
-  security.pam.sshAgentAuth.enable = false;
+  security.pam.sshAgentAuth.enable = lib.mkForce false; # Require mkforce if you want to disable.
 
   # Enable touchpad support (enabled default in most desktopManager).
   services.libinput = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -35,7 +35,6 @@
   # Pacthed packages
   (final: prev: {
     patched = {
-
       # TODO: Replace to stable since nixos-25.05, stable 24.11 does not include https://github.com/NixOS/nixpkgs/pull/361378
       lima = prev.unstable.lima.overrideAttrs (
         finalAttrs: previousAttrs:

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -21,7 +21,7 @@
   # Patched and override existing name because of it is not cofigurable
   (final: prev: {
     # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/gn/gnome-keyring/package.nix
-    # To disable SSH_AUTH_SOCK by gnome-keyring
+    # To disable SSH_AUTH_SOCK by gnome-keyring. This is required because of I should avoid GH-714 but realize GH-1015
     #
     # And it should be override the package it self, the module is not configurable for the package. https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/desktops/gnome/gnome-keyring.nix
     gnome-keyring = prev.gnome-keyring.overrideAttrs (

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -16,10 +16,26 @@
     };
   })
 
-  # Pacthed packages
+  # Keep minimum patches as possible. Because of they can not use official binary cache. See GH-754
 
+  # Patched and override existing name because of it is not cofigurable
+  (final: prev: {
+    # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/gn/gnome-keyring/package.nix
+    # To disable SSH_AUTH_SOCK by gnome-keyring
+    #
+    # And it should be override the package it self, the module is not configurable for the package. https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+    gnome-keyring = prev.gnome-keyring.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        # https://github.com/NixOS/nixpkgs/issues/140824#issuecomment-2573660493
+        configureFlags = final.lib.lists.remove "--enable-ssh-agent" previousAttrs.configureFlags;
+      }
+    );
+  })
+
+  # Pacthed packages
   (final: prev: {
     patched = {
+
       # TODO: Replace to stable since nixos-25.05, stable 24.11 does not include https://github.com/NixOS/nixpkgs/pull/361378
       lima = prev.unstable.lima.overrideAttrs (
         finalAttrs: previousAttrs:


### PR DESCRIPTION
Closes GH-1034 and Closes GH-1036

Fixes GH-1015 with updating GH-978 and GH-814
