### PR TITLE
Fix default PDF reader when open in GNOME

### DIFF
--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -1,29 +1,29 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
+let
+  defaultBrowser = [
+    "google-chrome.desktop"
+    "firefox.desktop"
+  ];
+in
 {
   imports = [ ./gnome.nix ];
-
-  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/home-environment.nix#
-  # https://github.com/nix-community/home-manager/blob/release-24.11/modules/lib/dag.nix
-  home = {
-    activation = {
-      # defaultApplications in xdg=* modules do not support except mime types. So required this for hotkey use
-      setDefaultBrowser = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        run '${pkgs.xdg-utils}/bin/xdg-settings' set 'default-web-browser' 'google-chrome.desktop'
-      '';
-    };
-  };
 
   xdg = {
     # https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-mime-apps.nix - different of  https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/config/xdg/mime.nix
     mimeApps = {
-      enable = true; # Required to enable even though it is alerting `bin/xdg-mime: line 1002: hm_mimeapps.list.new: Read-only file system`
-      defaultApplications = {
-        "application/pdf" = [
-          "google-chrome.desktop"
-          "firefox.desktop"
-        ];
-      };
+      enable = true;
+      # Don't use `xdg-settings set default-web-browser`.
+      # https://github.com/nix-community/home-manager/issues/96#issuecomment-343650659 is old. Using both made errors such as https://github.com/kachick/dotfiles/pull/1038#discussion_r1910360832
+      # So use only xdg.mimeApps
+      defaultApplications = lib.genAttrs [
+        "text/html"
+        "x-scheme-handler/http"
+        "x-scheme-handler/https"
+        "x-scheme-handler/about"
+        "x-scheme-handler/unknown"
+        "application/pdf" # I prefer to open PDF with reader, editor is not frequently used.
+      ] (_: defaultBrowser);
     };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -17,7 +17,7 @@
   xdg = {
     # https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-mime-apps.nix - different of  https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/config/xdg/mime.nix
     mimeApps = {
-      enable = true;
+      enable = true; # Required to enable even though it is alerting `bin/xdg-mime: line 1002: hm_mimeapps.list.new: Read-only file system`
       defaultApplications = {
         "application/pdf" = [
           "google-chrome.desktop"

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -17,7 +17,7 @@
   xdg = {
     # https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-mime-apps.nix - different of  https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/config/xdg/mime.nix
     mimeApps = {
-      enable = false; # Avoiding error: bin/xdg-mime: line 1002: hm_mimeapps.list.new: Read-only file system
+      enable = true;
       defaultApplications = {
         "application/pdf" = [
           "google-chrome.desktop"

--- a/nixos/desktop/GUI.md
+++ b/nixos/desktop/GUI.md
@@ -17,7 +17,7 @@ Q: How to persist this config from settings menu?\
 A: `dconf watch /`
 
 Q: Why default-apps changes will not be appeared in dconf watch?\
-A: `xdg-settings get default-web-browser`
+A: Use `xdg.mimeApps` module in home-manager
 
 Q: [Broken cursor as white square](https://github.com/NixOS/nixpkgs/issues/140505#issuecomment-1637341617)\
 A: `dconf reset /org/gnome/desktop/interface/cursor-theme`


### PR DESCRIPTION
Fix PDF default reader with removing conflict implementation which introduced in GH-953