### PR TITLE
Use forked home-manager  to apply a patch in release-24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,15 +39,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1736373539,
-        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
-        "owner": "nix-community",
+        "lastModified": 1737954034,
+        "narHash": "sha256-TbjPf48Z85zgOZjBXLmx+elczAUM7c/Ik7oTDcZc6mY=",
+        "owner": "kachick",
         "repo": "home-manager",
-        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
+        "rev": "f33926dadd874bb4e7b46e5ee9bb5102842b6665",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "kachick",
         "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
@@ -60,15 +60,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1736373539,
-        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
-        "owner": "nix-community",
+        "lastModified": 1737954034,
+        "narHash": "sha256-TbjPf48Z85zgOZjBXLmx+elczAUM7c/Ik7oTDcZc6mY=",
+        "owner": "kachick",
         "repo": "home-manager",
-        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
+        "rev": "f33926dadd874bb4e7b46e5ee9bb5102842b6665",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "kachick",
         "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
     # https://github.com/nix-community/home-manager/blob/release-24.11/docs/manual/nix-flakes.md
     home-manager-linux = {
-      # Using forked repository because of to apply https://github.com/nix-community/home-manager/pull/6357 for syable channel
+      # Using forked repository because of to apply https://github.com/nix-community/home-manager/pull/6357 in stable channel
       # See https://github.com/kachick/dotfiles/issues/1051 for detail
       url = "github:kachick/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -13,11 +13,13 @@
     nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
     # https://github.com/nix-community/home-manager/blob/release-24.11/docs/manual/nix-flakes.md
     home-manager-linux = {
-      url = "github:nix-community/home-manager/release-24.11";
+      # Using forked repository because of to apply https://github.com/nix-community/home-manager/pull/6357 for syable channel
+      # See https://github.com/kachick/dotfiles/issues/1051 for detail
+      url = "github:kachick/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager-darwin = {
-      url = "github:nix-community/home-manager/release-24.11";
+      url = "github:kachick/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs-darwin";
     };
     nixos-wsl = {


### PR DESCRIPTION
Attempt to avoid very unstable sr.ht

ref: https://github.com/kachick/dotfiles/issues/1051

Motivation: Non related CI is failing https://github.com/kachick/dotfiles/pull/1058#issuecomment-2616580000 😠 