### PR TITLE
Use no-patched lima again with suppressing `Unsupported option "gssapiauthentication"` in IgnoreUnknown

### DIFF
--- a/home-manager/lima-host.nix
+++ b/home-manager/lima-host.nix
@@ -5,13 +5,17 @@
   ...
 }:
 let
-  lima = pkgs.patched.lima;
+  # TODO: Replace to stable since nixos-25.05, stable 24.11 does not include https://github.com/NixOS/nixpkgs/pull/361378
+  lima = pkgs.unstable.lima;
 in
 {
   programs.ssh.includes = [
-    # * lima does not support XDG spec. https://github.com/lima-vm/lima/discussions/2745#discussioncomment-10958677
-    # * adding this as `ssh -F` makes it possible to use ssh login, it is required for `ms-vscode-remote.remote-ssh`
-    # * the content of file will be changed for each instance creation
+    # * Why SSH is required
+    #     Lima can generate ssh config and adding it as `ssh -F` makes it possible to use ssh login.
+    #     And we also use the shell as `lima` without ssh.
+    #     However It is not enough for use of `ms-vscode-remote.remote-ssh`.
+    # * Why put under .lima
+    #   lima does not support XDG spec. https://github.com/lima-vm/lima/discussions/2745#discussioncomment-10958677
     "${config.home.homeDirectory}/.lima/default/ssh.config"
   ];
 

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  lib,
   config,
   ...
 }:
@@ -71,19 +72,23 @@ in
 
     # https://www.clear-code.com/blog/2023/4/3/recommended-ssh-config.html
     # https://gitlab.com/clear-code/ssh.d/-/blob/main/global.conf?ref_type=heads
-    extraConfig = ''
-      PasswordAuthentication no
+    extraConfig =
+      ''
+        PasswordAuthentication no
 
-      # default: "ask"
-      StrictHostKeyChecking yes
+        # default: "ask"
+        StrictHostKeyChecking yes
 
-      # https://serverfault.com/a/1109184/112217
-      CheckHostIP no
-
-      # `UseKeychain` only provided by darwin ssh agent, in Linux and pkgs.openssh, it isn't
-      IgnoreUnknown UseKeychain
-      UseKeychain yes
-    '';
+        # https://serverfault.com/a/1109184/112217
+        CheckHostIP no
+      ''
+      + (
+        # `UseKeychain` only provided by darwin ssh agent, in Linux and pkgs.openssh, it isn't
+        lib.strings.optionalString pkgs.stdenv.hostPlatform.isDarwin ''
+          IgnoreUnknown UseKeychain
+          UseKeychain yes
+        ''
+      );
 
     # No problem to register the same *.pub in different services
     matchBlocks = {

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -70,6 +70,12 @@ in
     # Enable custom or temporary config without `home-manager switch`
     includes = [ "${sshDir}/config.local" ];
 
+    # Workaround for GH-950
+    extraOptionOverrides = {
+      # https://github.com/sul-dlss/DeveloperPlaybook/blob/32b384111f7f6a79ec21f305cf4bdd10e8292f5c/best-practices/ssh_configuration.md?plain=1#L14-L15
+      IgnoreUnknown = "GSSAPI*";
+    };
+
     # https://www.clear-code.com/blog/2023/4/3/recommended-ssh-config.html
     # https://gitlab.com/clear-code/ssh.d/-/blob/main/global.conf?ref_type=heads
     extraConfig =
@@ -81,10 +87,6 @@ in
 
         # https://serverfault.com/a/1109184/112217
         CheckHostIP no
-
-        # Workaround for GH-950
-        # See https://github.com/NixOS/nixops/issues/395#issuecomment-2632428059
-        IgnoreUnknown gssapikexalgorithms,gssapiauthentication,gssapidelegatecredentials
       ''
       + (
         # `UseKeychain` only provided by darwin ssh agent, in Linux and pkgs.openssh, it isn't

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -81,6 +81,10 @@ in
 
         # https://serverfault.com/a/1109184/112217
         CheckHostIP no
+
+        # Workaround for GH-950
+        # See https://github.com/NixOS/nixops/issues/395#issuecomment-2632428059
+        IgnoreUnknown gssapikexalgorithms,gssapiauthentication,gssapidelegatecredentials
       ''
       + (
         # `UseKeychain` only provided by darwin ssh agent, in Linux and pkgs.openssh, it isn't
@@ -92,11 +96,6 @@ in
 
     # No problem to register the same *.pub in different services
     matchBlocks = {
-      # Workaround for GH-950
-      # See https://github.com/NixOS/nixops/issues/395#issuecomment-2632428059
-      "*".extraOptions.IgnoreUnknown =
-        "gssapikexalgorithms,gssapiauthentication,gssapidelegatecredentials";
-
       # ANYONE can access the registered public key at https://github.com/kachick.keys
       "github.com" = sharedConfig;
 

--- a/home-manager/ssh.nix
+++ b/home-manager/ssh.nix
@@ -87,6 +87,11 @@ in
 
     # No problem to register the same *.pub in different services
     matchBlocks = {
+      # Workaround for GH-950
+      # See https://github.com/NixOS/nixops/issues/395#issuecomment-2632428059
+      "*".extraOptions.IgnoreUnknown =
+        "gssapikexalgorithms,gssapiauthentication,gssapidelegatecredentials";
+
       # ANYONE can access the registered public key at https://github.com/kachick.keys
       "github.com" = sharedConfig;
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -35,24 +35,6 @@
   # Pacthed packages
   (final: prev: {
     patched = {
-      # TODO: Replace to stable since nixos-25.05, stable 24.11 does not include https://github.com/NixOS/nixpkgs/pull/361378
-      lima = prev.unstable.lima.overrideAttrs (
-        finalAttrs: previousAttrs:
-        if prev.stdenv.hostPlatform.isLinux then
-          {
-            patches = [
-              (prev.fetchpatch {
-                # https://github.com/kachick/lima/pull/1
-                name = "lima-suppress-gssapi-warning.patch";
-                url = "https://patch-diff.githubusercontent.com/raw/kachick/lima/pull/1.patch";
-                hash = "sha256-QTEYorN+nj66WMlMz+hsoZUWPnlGPDCw0VSsqsiayls=";
-              })
-            ];
-          }
-        else
-          { }
-      );
-
       # TODO: Remove after merging https://github.com/NixOS/nixpkgs/pull/301440
       cozette = prev.cozette.overrideAttrs (
         finalAttrs: previousAttrs: {


### PR DESCRIPTION
To enable Nix official binary cache

Use another way of GH-960 to resolve GH-950

Closes https://github.com/kachick/lima/pull/1
Closes GH-1052