### PR TITLE
Fix unstable `go tool -n` result in lint cmd

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -8,12 +8,14 @@ on:
       - '**.nix'
       - 'flake.*'
       - 'Taskfile.yml'
+      - 'cmd/**'
   pull_request:
     paths:
       - '.github/workflows/ci-nix.yml'
       - '**.nix'
       - 'flake.*'
       - 'Taskfile.yml'
+      - 'cmd/**'
   schedule:
     # Every 10:42 JST
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -14,17 +14,20 @@ import (
 )
 
 func getExhaustructPath() string {
-	exhaustructResult, err := exec.Command("go", []string{"tool", "-n", "exhaustruct"}...).CombinedOutput()
+	// It downloads dependencies and outputs them in first run.
+	// And getting only last line made messy result. I didn't get the actual root cause of this problem... :<
+	cmd := func() *exec.Cmd { return exec.Command("go", []string{"tool", "-n", "exhaustruct"}...) }
+	err := cmd().Run()
+	if err != nil {
+		log.Fatalf("Failed to run exhaustruct: %+v", err)
+	}
+
+	exhaustructResult, err := cmd().CombinedOutput()
 	if err != nil {
 		log.Fatalf("Missing exhaustruct as a vettool: %+v", err)
 	}
 
-	// It downloads dependencies and outputs them in first run. So getting only last line here such as tail command
-	var last string
-	for line := range strings.Lines(string(exhaustructResult)) {
-		last = line
-	}
-	return strings.TrimSpace(last)
+	return strings.TrimSpace(string(exhaustructResult))
 }
 
 func main() {


### PR DESCRIPTION
- **Trigger cmd changes in Nix devshell CI**
- **Run `go tool -n` twice**
