### PR TITLE
Ruby strip go trim space

### DIFF
--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/default.nix
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/default.nix
@@ -6,8 +6,11 @@ pkgs.writeShellApplication rec {
     (import ../safe_quote_backtik { inherit pkgs; })
     git
     fzf
-    ruby_3_3
+    go_1_22
   ];
+  runtimeEnv = {
+    GO_SCRIPT_TO_NORMALIZE = "${./main.go}";
+  };
   meta = {
     description = "Used in git alias";
   };

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
@@ -5,6 +5,6 @@
 # - Keep line-end in fzf input
 # shellcheck disable=SC2016 disable=SC2086
 go run "$GO_SCRIPT_TO_NORMALIZE" |
-	fzf --height ''${FZF_TMUX_HEIGHT:-40%} ''${FZF_DEFAULT_OPTS-} \
+	fzf --height "${FZF_TMUX_HEIGHT:-40%}" "${FZF_DEFAULT_OPTS-}" \
 		-n2..,.. --scheme=history \
 		--bind 'enter:become(safe_quote_backtik {} | git commit -a -F -)'

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
@@ -1,9 +1,10 @@
-# Why ruby?
+# Preparation for the input
+#
 # - bash keeps whitespace prefix even specified -n option for fc -l
 # - lstrip is not enough for some history
 # - Keep line-end in fzf input
 # shellcheck disable=SC2016 disable=SC2086
-ruby -e 'STDIN.each { |line| puts line.strip }' |
+go run "$GO_SCRIPT_TO_NORMALIZE" |
 	fzf --height ''${FZF_TMUX_HEIGHT:-40%} ''${FZF_DEFAULT_OPTS-} \
 		-n2..,.. --scheme=history \
 		--bind 'enter:become(safe_quote_backtik {} | git commit -a -F -)'

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
@@ -7,4 +7,4 @@
 go run "$GO_SCRIPT_TO_NORMALIZE" |
 	fzf --height "${FZF_TMUX_HEIGHT:-40%}" "${FZF_DEFAULT_OPTS-}" \
 		-n2..,.. --scheme=history \
-		--bind 'enter:become(safe_quote_backtik {} | git commit -a -F -)'
+		--bind 'enter:become(safe_quote_backtik {} | command "$EDITOR" | git commit -a -F -)'

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/fzf-bind-posix-shell-history-to-git-commit-message.bash
@@ -5,6 +5,6 @@
 # - Keep line-end in fzf input
 # shellcheck disable=SC2016 disable=SC2086
 go run "$GO_SCRIPT_TO_NORMALIZE" |
-	fzf --height "${FZF_TMUX_HEIGHT:-40%}" "${FZF_DEFAULT_OPTS-}" \
+	fzf --height "${FZF_TMUX_HEIGHT:-40%}" $FZF_DEFAULT_OPTS \
 		-n2..,.. --scheme=history \
 		--bind 'enter:become(safe_quote_backtik {} | command "$EDITOR" | git commit -a -F -)'

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/go.mod
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/go.mod
@@ -1,0 +1,3 @@
+module github.com/kachick/dotfiles/pkgs/fzf-bind-posix-shell-history-to-git-commit-message
+
+go 1.22.5

--- a/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/main.go
+++ b/pkgs/fzf-bind-posix-shell-history-to-git-commit-message/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fmt.Println(strings.TrimSpace(line))
+	}
+}


### PR DESCRIPTION
This branch was superseded by https://github.com/kachick/dotfiles/pull/1083