### PR TITLE
Make scanning secrets faster by using gitleaks again instead of trufflehog

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -1,22 +1,35 @@
 name: 🙈 # TODO: Extract into external repository might be reasonable for these public repositories
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
-
+on: [pull_request, push, workflow_dispatch]
 jobs:
-  trufflehog: # 🍄 🐽
+  gitleaks:
     timeout-minutes: 15
+    name: gitleaks
     runs-on: ubuntu-24.04
+    env:
+      CLI_VERSION: '8.24.0' # selfup {"extract":"\\d[^']+","replacer":["gitleaks", "version"]}
     steps:
+      # gitleaks-action is unfree since v2, Don't refer the code even if used in personal repositories
+      # However I also don't use nixpkgs version here. The Nix footprint is much annoy for this purpose.
+      # So simply uses the pre-built CLI here.
+      - name: Download
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -OL 'https://github.com/gitleaks/gitleaks/releases/download/v${{ env.CLI_VERSION }}/gitleaks_${{ env.CLI_VERSION }}_linux_x64.tar.gz'
+          curl -OL 'https://github.com/gitleaks/gitleaks/releases/download/v${{ env.CLI_VERSION }}/gitleaks_${{ env.CLI_VERSION }}_checksums.txt'
+          sha256sum --check --ignore-missing gitleaks_${{ env.CLI_VERSION }}_checksums.txt
+      - name: Install
+        working-directory: ${{ runner.temp }}
+        run: |
+          tar zxvf gitleaks_${{ env.CLI_VERSION }}_linux_x64.tar.gz
+          mkdir --parents /home/runner/.gitleaks/bin
+          mv gitleaks /home/runner/.gitleaks/bin
+          echo '/home/runner/.gitleaks/bin' >> $GITHUB_PATH
+      - name: Make sure installed gitleaks version
+        run: 'gitleaks version'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Getting all refs for git mode
-      - name: Secret Scanning
-        # Okay for using the latest since specified the CLI version below. Consider to pin with a tag if the project looks unstable
-        uses: trufflesecurity/trufflehog@7dc056a193116ba8d82154bf0549381c8fb8545c # main
-        with:
-          extra_args: --results=verified,unknown
-          version: '3.88.13' # selfup {"extract":"\\d[^']+","replacer":["bash", "-c", "trufflehog --version 2>&1"],"nth":2}
+      - name: Run
+        # For CI use in public repositories, ensuring full-redact does not ensure to avoid actual problems, should not forget it :)
+        run: |
+          gitleaks git . --redact=100

--- a/cmd/deps/main.go
+++ b/cmd/deps/main.go
@@ -15,7 +15,7 @@ func main() {
 		{Path: "shellcheck", Args: []string{"--version"}},
 		{Path: "shfmt", Args: []string{"--version"}},
 		{Path: "typos", Args: []string{"--version"}},
-		{Path: "trufflehog", Args: []string{"--version"}},
+		{Path: "gitleaks", Args: []string{"version"}},
 		{Path: "nixpkgs-lint", Args: []string{"--version"}},
 		{Path: "selfup", Args: []string{"-version"}},
 

--- a/config/nushell/config.nu
+++ b/config/nushell/config.nu
@@ -64,5 +64,3 @@ alias g = git
 
 # https://github.com/NixOS/nixpkgs/pull/344193
 alias zed = zeditor
-
-alias hog = trufflehog

--- a/flake.nix
+++ b/flake.nix
@@ -128,8 +128,8 @@
                 ])
                 ++ (with pkgs.unstable; [
                   hydra-check # Background and how to use: https://github.com/kachick/dotfiles/pull/909#issuecomment-2453389909
-                  trufflehog
                   # https://github.com/NixOS/nixpkgs/pull/362139
+                  gitleaks # TODO: Consider to replace to stable since nixos-25.05. nixos-24.11 including version makes false-positive error now
                   dprint
                   lychee
                   go_1_24

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -84,9 +84,6 @@
 
       # https://github.com/NixOS/nixpkgs/pull/344193
       "zed" = "zeditor";
-
-      # I can't remember the spells...
-      "hog" = "trufflehog";
     };
   };
 

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -80,7 +80,7 @@
   hyperfine
   riffdiff # `riff`
   gnumake
-  unstable.trufflehog
+  unstable.gitleaks
   ruby_3_4
   _7zz # `7zz` - 7zip. Command is not 7zip.
 

--- a/pkgs/git-hooks-pre-push/package.nix
+++ b/pkgs/git-hooks-pre-push/package.nix
@@ -6,7 +6,7 @@ pkgs.writeShellApplication rec {
   runtimeInputs = with pkgs; [
     typos
     coreutils # `basename`
-    unstable.trufflehog
+    unstable.gitleaks
     my.run_local_hook
   ];
   runtimeEnv = {

--- a/pkgs/git-hooks-pre-push/pre-push.bash
+++ b/pkgs/git-hooks-pre-push/pre-push.bash
@@ -1,13 +1,16 @@
-# Avoiding -o error: https://stackoverflow.com/a/7832158
-# This is an escape hatch for large repository
-DO_HOOK=${RUN_GITHOOK_HOG:-true}
+# Providing env is an escape hatch
+# `SKIP` is adjusted for pre-commit convention. See https://github.com/gitleaks/gitleaks/blob/v8.24.0/README.md?plain=1#L121-L127
+# TODO: Consider multiple SKIP with CSV format such as they are using.
+# Copying to another env is avoiding -o error: https://stackoverflow.com/a/7832158
+SKIP_HOOK=${SKIP:-}
+
+DEFAULT_BRANCH="$(basename "$(git symbolic-ref 'refs/remotes/origin/HEAD')")"
 
 # list of arguments: https://git-scm.com/docs/githooks#_pre_push
 while read -r local_ref _local_oid remote_ref _remote_oid; do
-	# - trufflehog pre-commit hook having crucial limitations. https://github.com/trufflesecurity/trufflehog/blob/v3.88.0/README.md?plain=1#L628-L629
-	# - Adding `--since-commit main` made 10x slower... :<
-	if [[ "$DO_HOOK" != "false" ]]; then
-		trufflehog git "file://${PWD}" --results='verified,unknown' --branch "$local_ref" --fail
+	if [[ "$SKIP_HOOK" != "gitleaks" ]]; then
+		# TODO: Might be better to skip if author is another person in nixpkgs
+		gitleaks git --log-opts="$DEFAULT_BRANCH..$local_ref"
 	fi
 
 	# Git ref is not a file path, but avoiding a typos limitation for slash


### PR DESCRIPTION
This is not just a reverting 6e6045da4471876e49bb49a066fef762845982c9(GH-1013),
refined the github action and pre-push hook.
Also bumped gitleaks version to avoid false positive.

Closes GH-699
