### PR TITLE
Install quickemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ block-beta
     columns 3
 
     block:os:3
-        nixos(("❄")) macos(("🍎"))   windows(("🪟"))
+        nixos(("❄")) macos(("🍎")) windows(("🪟"))
     end
 
     block:vm:3
-        lima("Lima")   wsl2("WSL2")
+        lima("Lima") quickemu("Quickemu") wsl2("WSL2")
     end
 
     block:container:3
@@ -26,6 +26,7 @@ block-beta
     end
 
     nixos --> lima
+    nixos --> quickemu
     macos --> lima
     windows --> wsl2
 

--- a/home-manager/genericLinux.nix
+++ b/home-manager/genericLinux.nix
@@ -13,5 +13,7 @@
       # - Don't remove termnfo even if it is outdated
       TERMINFO_DIRS = "${pkgs.kitty.terminfo}/share/terminfo:${pkgs.unstable.ghostty.terminfo}/share/terminfo";
     };
+
+    packages = with pkgs; [ quickemu ];
   };
 }

--- a/home-manager/genericLinux.nix
+++ b/home-manager/genericLinux.nix
@@ -13,7 +13,5 @@
       # - Don't remove termnfo even if it is outdated
       TERMINFO_DIRS = "${pkgs.kitty.terminfo}/share/terminfo:${pkgs.unstable.ghostty.terminfo}/share/terminfo";
     };
-
-    packages = with pkgs; [ quickemu ];
   };
 }

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -41,6 +41,7 @@
           "dev.zed.Zed.desktop"
           "google-chrome.desktop"
           "podman-desktop.desktop"
+          "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -11,8 +11,11 @@
 
 {
   home = {
-    packages = with pkgs; [
-      unstable.zed-editor
+    packages = with pkgs.unstable; [
+      zed-editor
+
+      quickemu
+      quickgui
     ];
   };
 }

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -143,6 +143,9 @@
       # See GH-1049 for detail.
       qemu
 
+      quickemu
+      quickgui
+
       lapce # IME is not working on Windows, but stable even around IME on Wayland than vscode
 
       mission-center

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -143,8 +143,10 @@
       # See GH-1049 for detail.
       qemu
 
-      quickemu
-      quickgui
+      # Use latest to apply patches such as https://github.com/quickemu-project/quickemu/issues/1528
+      # Especially quickget requires latest definitions
+      unstable.quickemu
+      unstable.quickgui
 
       lapce # IME is not working on Windows, but stable even around IME on Wayland than vscode
 


### PR DESCRIPTION
Add a way into GH-793

CUI: lima
GUI: quickemu

for now

---


Extracted the usage in https://github.com/kachick/dotfiles/wiki/quickemu

And it looks not having data directory specified methods except CLI arguments. I would put them in XDG_DATA_DIR ...