### PR TITLE
Make it possible to detect Chrome profiles by the name, however give up to manage PWA in home-manager

### DIFF
--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  #  pkgs,
+  ...
+}:
 
 let
   defaultBrowser = [
@@ -65,52 +69,52 @@ in
     # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
     #
     # Don't quotate with 'content' in the desktop entry. Use "content"
-    desktopEntries = {
-      youtube-music-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
-        '';
-        name = "YouTube_Music";
-        settings = {
-          StartupWMClass = name;
-        };
-        # https://music.youtube.com/manifest.webmanifest
-        icon = "${pkgs.fetchurl {
-          url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
-          hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
-        }}";
-      };
+    # desktopEntries = {
+    #   youtube-music-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
+    #     '';
+    #     name = "YouTube_Music";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     # https://music.youtube.com/manifest.webmanifest
+    #     icon = "${pkgs.fetchurl {
+    #       url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
+    #       hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
+    #     }}";
+    #   };
 
-      # Amazon Music does not officially support PWA. However it is almost working.
-      amazon-music-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
-        '';
-        name = "Amazon_Music";
-        settings = {
-          StartupWMClass = name;
-        };
-        icon = "${pkgs.fetchurl {
-          # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
-          url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
-          hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
-        }}";
-      };
+    #   # Amazon Music does not officially support PWA. However it is almost working.
+    #   amazon-music-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
+    #     '';
+    #     name = "Amazon_Music";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     icon = "${pkgs.fetchurl {
+    #       # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
+    #       url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
+    #       hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
+    #     }}";
+    #   };
 
-      spotify-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
-        '';
-        name = "Spotify";
-        settings = {
-          StartupWMClass = name;
-        };
-        # It might be unstable with the their CDN URL
-        icon = "${pkgs.fetchurl {
-          url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
-          hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
-        }}";
-      };
-    };
+    #   spotify-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
+    #     '';
+    #     name = "Spotify";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     # It might be unstable with the their CDN URL
+    #     icon = "${pkgs.fetchurl {
+    #       url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
+    #       hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
+    #     }}";
+    #   };
+    # };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -65,52 +65,52 @@ in
     # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
     #
     # Don't quotate with 'content' in the desktop entry. Use "content"
-    # desktopEntries = {
-    #   youtube-music-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
-    #     '';
-    #     name = "YouTube_Music";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     # https://music.youtube.com/manifest.webmanifest
-    #     icon = "${pkgs.fetchurl {
-    #       url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
-    #       hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
-    #     }}";
-    #   };
+    desktopEntries = {
+      youtube-music-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
+        '';
+        name = "YouTube_Music";
+        settings = {
+          StartupWMClass = name;
+        };
+        # https://music.youtube.com/manifest.webmanifest
+        icon = "${pkgs.fetchurl {
+          url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
+          hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
+        }}";
+      };
 
-    #   # Amazon Music does not officially support PWA. However it is almost working.
-    #   amazon-music-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
-    #     '';
-    #     name = "Amazon_Music";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     icon = "${pkgs.fetchurl {
-    #       # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
-    #       url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
-    #       hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
-    #     }}";
-    #   };
+      # Amazon Music does not officially support PWA. However it is almost working.
+      amazon-music-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
+        '';
+        name = "Amazon_Music";
+        settings = {
+          StartupWMClass = name;
+        };
+        icon = "${pkgs.fetchurl {
+          # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
+          url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
+          hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
+        }}";
+      };
 
-    #   spotify-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
-    #     '';
-    #     name = "Spotify";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     # It might be unstable with the their CDN URL
-    #     icon = "${pkgs.fetchurl {
-    #       url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
-    #       hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
-    #     }}";
-    #   };
-    # };
+      spotify-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
+        '';
+        name = "Spotify";
+        settings = {
+          StartupWMClass = name;
+        };
+        # It might be unstable with the their CDN URL
+        icon = "${pkgs.fetchurl {
+          url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
+          hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
+        }}";
+      };
+    };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -56,67 +56,61 @@ in
     # - Duplicate icons will be listed in overview for the original PWA and this wrapper. So adding in dock would be better to avoid confusions
     #
     # - What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
+    # - How to get WM_CLASS on wayland?: Use lg(Looking Glass). See https://askubuntu.com/a/1468539
     #
     # Chrome originally sets the icon like `Icon=chrome-${app_id}-${profile_index (replaced space with _)}`, however it will not fit for managing by home-manager
     # So manually setting the icon here
     # Icons are defined in PWA manifest, it is specified in their <link> tag. https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons
     #
     # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
+    #
+    # Don't quotate with 'content' in the desktop entry. Use "content"
     desktopEntries = {
-      youtube-music-pwa =
-        let
-          name = "YouTube Music";
-        in
-        {
-          exec = ''
-            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app='https://music.youtube.com/'
-          '';
-          name = "YouTube Music";
-          settings = {
-            StartupWMClass = name;
-          };
-          # https://music.youtube.com/manifest.webmanifest
-          icon = "${pkgs.fetchurl {
-            url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
-            hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
-          }}";
+      youtube-music-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
+        '';
+        name = "YouTube_Music";
+        settings = {
+          StartupWMClass = name;
         };
+        # https://music.youtube.com/manifest.webmanifest
+        icon = "${pkgs.fetchurl {
+          url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
+          hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
+        }}";
+      };
 
       # Amazon Music does not officially support PWA. However it is almost working.
-      amazon-music-pwa =
-        let
-          name = "Amazon Music";
-        in
-        {
-          exec = ''
-            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app='https://music.amazon.co.jp/'
-          '';
-          name = "Amazon Music";
-          settings = {
-            StartupWMClass = name;
-          };
-          icon = "${pkgs.fetchurl {
-            # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
-            url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
-            hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
-          }}";
+      amazon-music-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
+        '';
+        name = "Amazon_Music";
+        settings = {
+          StartupWMClass = name;
         };
+        icon = "${pkgs.fetchurl {
+          # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
+          url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
+          hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
+        }}";
+      };
 
-      spotify-pwa =
-        let
-          app-id = "pjibgclleladliembfgfagdaldikeohf";
-        in
-        {
-          exec = ''
-            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
-          '';
-          name = "Spotify";
-          # It might be unstable with the their CDN URL
-          icon = "${pkgs.fetchurl {
-            url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
-            hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
-          }}";
+      spotify-pwa = rec {
+        exec = ''
+          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
+        '';
+        name = "Spotify";
+        settings = {
+          StartupWMClass = name;
         };
+        # It might be unstable with the their CDN URL
+        icon = "${pkgs.fetchurl {
+          url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
+          hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
+        }}";
+      };
     };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -53,6 +53,10 @@ in
     #   See https://askubuntu.com/questions/117341/how-can-i-find-desktop-files
     #
     # What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
+    #
+    # Chrome originally sets the icon like `Icon=chrome-${app_id}-${profile_index (replaced space with _)}`, however it will not fit for managing by home-manager
+    # So manually setting the icon here
+    # Icons are defined in PWA manifest, it is specified in their <link> tag. https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons
     desktopEntries = {
       youtube-music-pwa =
         let
@@ -63,8 +67,14 @@ in
             ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
           '';
           name = "YouTube Music";
+          # https://music.youtube.com/manifest.webmanifest
+          icon = "${pkgs.fetchurl {
+            url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
+            hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
+          }}";
         };
 
+      # Amazon Music does not officially support PWA. However it is almost working.
       amazon-music-pwa =
         let
           app-id = "dojpeppajphepagdhclblkkjnoaeamee";
@@ -74,6 +84,11 @@ in
             ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
           '';
           name = "Amazon Music";
+          icon = "${pkgs.fetchurl {
+            # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
+            url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
+            hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
+          }}";
         };
     };
   };

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -51,6 +51,7 @@ in
     #   - https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-desktop-entries.nix
     #   - Such as files in ~/.local/share/applications by GNOME default as written in https://askubuntu.com/questions/117341/how-can-i-find-desktop-files, however this module does not put on there
     #
+    # - Required to install PWA itself from browser even if activated these shortcuts. However this definition is also required to share the desktop file in all NixOS device
     # - Required to log-out from GNOME to apply in overview
     #
     # - What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -49,10 +49,11 @@ in
     # - Related Modules:
     #   - https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/build-support/make-desktopitem/default.nix
     #   - https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-desktop-entries.nix
-    # - Put in ~/.local/share/applications
-    #   See https://askubuntu.com/questions/117341/how-can-i-find-desktop-files
+    #   - Such as files in ~/.local/share/applications by GNOME default as written in https://askubuntu.com/questions/117341/how-can-i-find-desktop-files, however this module does not put on there
     #
-    # What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
+    # - Required to log-out from GNOME to apply in overview
+    #
+    # - What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
     #
     # Chrome originally sets the icon like `Icon=chrome-${app_id}-${profile_index (replaced space with _)}`, however it will not fit for managing by home-manager
     # So manually setting the icon here

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -60,16 +60,21 @@ in
     # Chrome originally sets the icon like `Icon=chrome-${app_id}-${profile_index (replaced space with _)}`, however it will not fit for managing by home-manager
     # So manually setting the icon here
     # Icons are defined in PWA manifest, it is specified in their <link> tag. https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons
+    #
+    # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
     desktopEntries = {
       youtube-music-pwa =
         let
-          app-id = "cinhimbnkkaeohfgghhklpknlkffjgod";
+          name = "YouTube Music";
         in
         {
           exec = ''
-            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
+            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app='https://music.youtube.com/'
           '';
           name = "YouTube Music";
+          settings = {
+            StartupWMClass = name;
+          };
           # https://music.youtube.com/manifest.webmanifest
           icon = "${pkgs.fetchurl {
             url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
@@ -80,13 +85,16 @@ in
       # Amazon Music does not officially support PWA. However it is almost working.
       amazon-music-pwa =
         let
-          app-id = "dojpeppajphepagdhclblkkjnoaeamee";
+          name = "Amazon Music";
         in
         {
           exec = ''
-            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
+            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app='https://music.amazon.co.jp/'
           '';
           name = "Amazon Music";
+          settings = {
+            StartupWMClass = name;
+          };
           icon = "${pkgs.fetchurl {
             # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
             url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -65,52 +65,52 @@ in
     # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
     #
     # Don't quotate with 'content' in the desktop entry. Use "content"
-    desktopEntries = {
-      youtube-music-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
-        '';
-        name = "YouTube_Music";
-        settings = {
-          StartupWMClass = name;
-        };
-        # https://music.youtube.com/manifest.webmanifest
-        icon = "${pkgs.fetchurl {
-          url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
-          hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
-        }}";
-      };
+    # desktopEntries = {
+    #   youtube-music-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
+    #     '';
+    #     name = "YouTube_Music";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     # https://music.youtube.com/manifest.webmanifest
+    #     icon = "${pkgs.fetchurl {
+    #       url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
+    #       hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
+    #     }}";
+    #   };
 
-      # Amazon Music does not officially support PWA. However it is almost working.
-      amazon-music-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
-        '';
-        name = "Amazon_Music";
-        settings = {
-          StartupWMClass = name;
-        };
-        icon = "${pkgs.fetchurl {
-          # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
-          url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
-          hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
-        }}";
-      };
+    #   # Amazon Music does not officially support PWA. However it is almost working.
+    #   amazon-music-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
+    #     '';
+    #     name = "Amazon_Music";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     icon = "${pkgs.fetchurl {
+    #       # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
+    #       url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
+    #       hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
+    #     }}";
+    #   };
 
-      spotify-pwa = rec {
-        exec = ''
-          ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
-        '';
-        name = "Spotify";
-        settings = {
-          StartupWMClass = name;
-        };
-        # It might be unstable with the their CDN URL
-        icon = "${pkgs.fetchurl {
-          url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
-          hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
-        }}";
-      };
-    };
+    #   spotify-pwa = rec {
+    #     exec = ''
+    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
+    #     '';
+    #     name = "Spotify";
+    #     settings = {
+    #       StartupWMClass = name;
+    #     };
+    #     # It might be unstable with the their CDN URL
+    #     icon = "${pkgs.fetchurl {
+    #       url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
+    #       hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
+    #     }}";
+    #   };
+    # };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -91,6 +91,22 @@ in
             hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
           }}";
         };
+
+      spotify-pwa =
+        let
+          app-id = "pjibgclleladliembfgfagdaldikeohf";
+        in
+        {
+          exec = ''
+            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
+          '';
+          name = "Spotify";
+          # It might be unstable with the their CDN URL
+          icon = "${pkgs.fetchurl {
+            url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
+            hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
+          }}";
+        };
     };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -53,6 +53,7 @@ in
     #
     # - Required to install PWA itself from browser even if activated these shortcuts. However this definition is also required to share the desktop file in all NixOS device
     # - Required to log-out from GNOME to apply in overview
+    # - Duplicate icons will be listed in overview for the original PWA and this wrapper. So adding in dock would be better to avoid confusions
     #
     # - What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
     #

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 let
   defaultBrowser = [
@@ -44,6 +44,37 @@ in
           "image/svg+xml"
           "image/svg+xml-compressed"
         ] (_: imageViewer));
+    };
+
+    # - Related Modules:
+    #   - https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/build-support/make-desktopitem/default.nix
+    #   - https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-desktop-entries.nix
+    # - Put in ~/.local/share/applications
+    #   See https://askubuntu.com/questions/117341/how-can-i-find-desktop-files
+    #
+    # What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
+    desktopEntries = {
+      youtube-music-pwa =
+        let
+          app-id = "cinhimbnkkaeohfgghhklpknlkffjgod";
+        in
+        {
+          exec = ''
+            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
+          '';
+          name = "YouTube Music";
+        };
+
+      amazon-music-pwa =
+        let
+          app-id = "dojpeppajphepagdhclblkkjnoaeamee";
+        in
+        {
+          exec = ''
+            ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app-id=${app-id}
+          '';
+          name = "Amazon Music";
+        };
     };
   };
 }

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  #  pkgs,
   ...
 }:
 
@@ -49,72 +48,5 @@ in
           "image/svg+xml-compressed"
         ] (_: imageViewer));
     };
-
-    # - Related Modules:
-    #   - https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/build-support/make-desktopitem/default.nix
-    #   - https://github.com/nix-community/home-manager/blob/release-24.11/modules/misc/xdg-desktop-entries.nix
-    #   - Such as files in ~/.local/share/applications by GNOME default as written in https://askubuntu.com/questions/117341/how-can-i-find-desktop-files, however this module does not put on there
-    #
-    # - Required to install PWA itself from browser even if activated these shortcuts. However this definition is also required to share the desktop file in all NixOS device
-    # - Required to log-out from GNOME to apply in overview
-    # - Duplicate icons will be listed in overview for the original PWA and this wrapper. So adding in dock would be better to avoid confusions
-    #
-    # - What is the StartupWMClass?: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
-    # - How to get WM_CLASS on wayland?: Use lg(Looking Glass). See https://askubuntu.com/a/1468539
-    #
-    # Chrome originally sets the icon like `Icon=chrome-${app_id}-${profile_index (replaced space with _)}`, however it will not fit for managing by home-manager
-    # So manually setting the icon here
-    # Icons are defined in PWA manifest, it is specified in their <link> tag. https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons
-    #
-    # Prefer url(app) instead of PWA(app-id) to avoid chrome profile number problem
-    #
-    # Don't quotate with 'content' in the desktop entry. Use "content"
-    # desktopEntries = {
-    #   youtube-music-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.youtube.com/"
-    #     '';
-    #     name = "YouTube_Music";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     # https://music.youtube.com/manifest.webmanifest
-    #     icon = "${pkgs.fetchurl {
-    #       url = "https://www.gstatic.com/youtube/media/ytm/images/applauncher/cairo/music_icon_512x512.png";
-    #       hash = "sha256-h51FhG7ouDqaz03Q6SK/Qs2XRhpIOQL/SwkltjmrnYQ=";
-    #     }}";
-    #   };
-
-    #   # Amazon Music does not officially support PWA. However it is almost working.
-    #   amazon-music-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://music.amazon.co.jp/"
-    #     '';
-    #     name = "Amazon_Music";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     icon = "${pkgs.fetchurl {
-    #       # Using different domain. However this URL was got from <link> tag in https://music.amazon.co.jp
-    #       url = "https://d5fx445wy2wpk.cloudfront.net/icons/amznMusic_favicon.png";
-    #       hash = "sha256-BH//RZsuRVa4QoxAiL55iOEVftNYCljbsDjFLIZLIjs=";
-    #     }}";
-    #   };
-
-    #   spotify-pwa = rec {
-    #     exec = ''
-    #       ${lib.getExe pkgs.my.chrome-with-profile-by-name} personal --app="https://open.spotify.com/"
-    #     '';
-    #     name = "Spotify";
-    #     settings = {
-    #       StartupWMClass = name;
-    #     };
-    #     # It might be unstable with the their CDN URL
-    #     icon = "${pkgs.fetchurl {
-    #       url = "https://open.spotifycdn.com/cdn/images/icons/Spotify_512.7e07796d.png";
-    #       hash = "sha256-fgd5bZ+qDCkeJQYNLRQJo1WKUBHGaoufVhlkC8PLR+0=";
-    #     }}";
-    #   };
-    # };
   };
 }

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,6 +42,9 @@
           "podman-desktop.desktop"
           "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
+          "youtube-music-pwa.desktop"
+          "amazon-music-pwa.desktop"
+          "spotify-pwa.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"
         ];
@@ -257,6 +260,9 @@
       "org/gnome/shell/extensions/auto-move-windows" = {
         application-list = [
           "org.gnome.Rhythmbox3.desktop:3"
+          "youtube-music-pwa.desktop:3"
+          "amazon-music-pwa.desktop:3"
+          "spotify-pwa.desktop:3"
         ];
       };
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,9 +42,9 @@
           "podman-desktop.desktop"
           "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
-          "youtube-music-pwa.desktop"
-          "amazon-music-pwa.desktop"
-          "spotify-pwa.desktop"
+          # "youtube-music-pwa.desktop"
+          # "amazon-music-pwa.desktop"
+          # "spotify-pwa.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"
         ];
@@ -265,9 +265,9 @@
           [
             "org.gnome.Rhythmbox3.desktop:${music}"
             # FIXME: Not working
-            "youtube-music-pwa.desktop:${music}"
-            "amazon-music-pwa.desktop:${music}"
-            "spotify-pwa.desktop:${music}"
+            # "youtube-music-pwa.desktop:${music}"
+            # "amazon-music-pwa.desktop:${music}"
+            # "spotify-pwa.desktop:${music}"
           ];
       };
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,9 +42,6 @@
           "podman-desktop.desktop"
           "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
-          # "youtube-music-pwa.desktop"
-          # "amazon-music-pwa.desktop"
-          # "spotify-pwa.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"
         ];
@@ -264,10 +261,6 @@
           in
           [
             "org.gnome.Rhythmbox3.desktop:${music}"
-            # # FIXME: Not working
-            # "youtube-music-pwa.desktop:${music}"
-            # "amazon-music-pwa.desktop:${music}"
-            # "spotify-pwa.desktop:${music}"
           ];
       };
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -258,12 +258,17 @@
       };
 
       "org/gnome/shell/extensions/auto-move-windows" = {
-        application-list = [
-          "org.gnome.Rhythmbox3.desktop:3"
-          "youtube-music-pwa.desktop:3"
-          "amazon-music-pwa.desktop:3"
-          "spotify-pwa.desktop:3"
-        ];
+        application-list =
+          let
+            music = "3";
+          in
+          [
+            "org.gnome.Rhythmbox3.desktop:${music}"
+            # FIXME: Not working
+            "youtube-music-pwa.desktop:${music}"
+            "amazon-music-pwa.desktop:${music}"
+            "spotify-pwa.desktop:${music}"
+          ];
       };
 
       "org/gnome/shell/extensions/user-theme" = {

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,9 +42,9 @@
           "podman-desktop.desktop"
           "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
-          # "youtube-music-pwa.desktop"
-          # "amazon-music-pwa.desktop"
-          # "spotify-pwa.desktop"
+          "youtube-music-pwa.desktop"
+          "amazon-music-pwa.desktop"
+          "spotify-pwa.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"
         ];
@@ -265,9 +265,9 @@
           [
             "org.gnome.Rhythmbox3.desktop:${music}"
             # FIXME: Not working
-            # "youtube-music-pwa.desktop:${music}"
-            # "amazon-music-pwa.desktop:${music}"
-            # "spotify-pwa.desktop:${music}"
+            "youtube-music-pwa.desktop:${music}"
+            "amazon-music-pwa.desktop:${music}"
+            "spotify-pwa.desktop:${music}"
           ];
       };
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -42,9 +42,9 @@
           "podman-desktop.desktop"
           "quickgui.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
-          "youtube-music-pwa.desktop"
-          "amazon-music-pwa.desktop"
-          "spotify-pwa.desktop"
+          # "youtube-music-pwa.desktop"
+          # "amazon-music-pwa.desktop"
+          # "spotify-pwa.desktop"
           "org.gnome.Rhythmbox3.desktop"
           "org.gnome.Nautilus.desktop"
         ];
@@ -264,10 +264,10 @@
           in
           [
             "org.gnome.Rhythmbox3.desktop:${music}"
-            # FIXME: Not working
-            "youtube-music-pwa.desktop:${music}"
-            "amazon-music-pwa.desktop:${music}"
-            "spotify-pwa.desktop:${music}"
+            # # FIXME: Not working
+            # "youtube-music-pwa.desktop:${music}"
+            # "amazon-music-pwa.desktop:${music}"
+            # "spotify-pwa.desktop:${music}"
           ];
       };
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -231,6 +231,8 @@
           "--wayland-text-input-version=3"
         ];
       })
+
+      my.chrome-with-profile-by-name
     ])
     ++ (with pkgs.gnomeExtensions; [
       appindicator

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -80,7 +80,7 @@
   environment.gnome.excludePackages = with pkgs; [
     gnome-tour
     gnome-connections
-    # epiphany # web browser # Required for better PWA experience in GNOME. To avoid chrome profile number and Firefox does not support PWAS/SSB for now
+    epiphany # web browser
     geary # email reader
     evince # document viewer
     gnome-calendar
@@ -164,7 +164,7 @@
       # tramhao/termusic and tsirysndr/music-player does not figure how to use.
       rhythmbox
 
-      evtest # To debug keyremapper as GH-786fepiphany
+      evtest # To debug keyremapper as GH-786
       psmisc # e.g. `fuser -v /dev/input/event17` when want to know event17 is grabbed by which process
 
       newsflash # `io.gitlab.news_flash.NewsFlash`

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -122,7 +122,6 @@
   environment.systemPackages =
     (with pkgs; [
       firefox
-      floorp # Only installing for PWA use, for now. Chrome PWA with considering the profile number is annoy in nix and home-manager configurations. See GH-968
 
       # https://github.com/NixOS/nixpkgs/issues/33282
       xdg-user-dirs

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -80,7 +80,7 @@
   environment.gnome.excludePackages = with pkgs; [
     gnome-tour
     gnome-connections
-    epiphany # web browser
+    # epiphany # web browser # Required for better PWA experience in GNOME. To avoid chrome profile number and Firefox does not support PWAS/SSB for now
     geary # email reader
     evince # document viewer
     gnome-calendar
@@ -164,7 +164,7 @@
       # tramhao/termusic and tsirysndr/music-player does not figure how to use.
       rhythmbox
 
-      evtest # To debug keyremapper as GH-786
+      evtest # To debug keyremapper as GH-786fepiphany
       psmisc # e.g. `fuser -v /dev/input/event17` when want to know event17 is grabbed by which process
 
       newsflash # `io.gitlab.news_flash.NewsFlash`

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -133,6 +133,7 @@
       unstable.zed-editor
 
       gdm-settings
+      desktop-file-utils # `desktop-file-validate`
 
       ghostty # ghostty package now always be backported. TODO: Prefer `unstable` since nixos-25.05
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -122,6 +122,7 @@
   environment.systemPackages =
     (with pkgs; [
       firefox
+      floorp # Only installing for PWA use, for now. Chrome PWA with considering the profile number is annoy in nix and home-manager configurations. See GH-968
 
       # https://github.com/NixOS/nixpkgs/issues/33282
       xdg-user-dirs

--- a/pkgs/chrome-with-profile-by-name/chrome-with-profile-by-name.bash
+++ b/pkgs/chrome-with-profile-by-name/chrome-with-profile-by-name.bash
@@ -1,0 +1,9 @@
+profile_name="$1"
+shift
+
+# I got the path from https://superuser.com/a/1663491/120469
+get_profile_id_by_name() {
+	jq --arg profile_name "$profile_name" -r '.profile.info_cache | to_entries | .[] | select(.value.name == $profile_name) | .key' "$XDG_CONFIG_HOME/google-chrome/Local State"
+}
+
+google-chrome-stable "--profile-directory=$(get_profile_id_by_name)" "$@"

--- a/pkgs/chrome-with-profile-by-name/package.nix
+++ b/pkgs/chrome-with-profile-by-name/package.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+pkgs.writeShellApplication rec {
+  name = "chrome-with-profile-by-name";
+  text = builtins.readFile ./${name}.bash;
+  runtimeInputs = with pkgs; [
+    # Don't add chrome in this dependency. Using with the command name is enough for this purpose
+    jq
+  ];
+  meta = {
+    description = "GH-968";
+  };
+}


### PR DESCRIPTION
~Resolves~ Closes GH-968