### PR TITLE
Implement system level initializer for non NixOS Linux

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -74,7 +74,7 @@ jobs:
       # https://www.reddit.com/r/Nix/comments/1443k3o/comment/jr9ht5g/?utm_source=reddit&utm_medium=web2x&context=3
       - run: mkdir -p ~/.local/state/nix/profiles
       - run: nix run .#home-manager -- switch -b backup --flake '.#github-actions@${{ matrix.os }}'
-      - run: zsh -c 'sudoc nix run ".#apply-system"'
+      - run: zsh --interactive -c 'sudoc nix run ".#apply-system"'
         if: runner.os == 'Linux'
       - name: Print some paths and versions
         run: |

--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -74,6 +74,8 @@ jobs:
       # https://www.reddit.com/r/Nix/comments/1443k3o/comment/jr9ht5g/?utm_source=reddit&utm_medium=web2x&context=3
       - run: mkdir -p ~/.local/state/nix/profiles
       - run: nix run .#home-manager -- switch -b backup --flake '.#github-actions@${{ matrix.os }}'
+      - run: zsh -c 'sudoc nix run ".#apply-system"'
+        if: runner.os == 'Linux'
       - name: Print some paths and versions
         run: |
           which zsh

--- a/README.md
+++ b/README.md
@@ -120,17 +120,10 @@ nix eval --json 'github:kachick/dotfiles#homeConfigurations' --apply 'builtins.a
    nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#wsl-ubuntu'
    ```
 
-1. [home-manager installed OpenSSH disabled GSSAPI by default](https://github.com/kachick/dotfiles/issues/950).\
-   So suppress `/etc/ssh/ssh_config line 53: Unsupported option "gssapiauthentication"` with following command
+1. Apply system level dotfiles
 
    ```bash
-   sudo chmod -r /etc/ssh/ssh_config
-   ```
-
-1. If you faced to lcoale errors such as `-bash: warning: setlocale: LC_TIME: cannot change locale (en_DK.UTF-8): No such file or directory`
-
-   ```bash
-   sudo localedef -f UTF-8 -i en_DK en_DK.UTF-8
+   sudo -s "$(command -v nix)" run 'github:kachick/dotfiles#apply-system'
    ```
 
 ### Podman on Ubuntu
@@ -141,14 +134,6 @@ nix eval --json 'github:kachick/dotfiles#homeConfigurations' --apply 'builtins.a
 
    ```bash
    sudo apt-get install --assume-yes uidmap
-   ```
-
-1. Make sure putting /etc/containers/policy.json, it is not a home-manager role
-
-   ```bash
-   sudo mkdir -p /etc/containers
-   cd /etc/containers
-   sudo curl -OL https://raw.githubusercontent.com/kachick/dotfiles/main/config/containers/policy.json
    ```
 
 1. Make sure the cgroup v1 is disabled if you on WSL, See [the docs](windows/WSL/README.md)

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ nix eval --json 'github:kachick/dotfiles#homeConfigurations' --apply 'builtins.a
    nix run 'github:kachick/dotfiles#home-manager' -- switch -b backup --flake 'github:kachick/dotfiles#wsl-ubuntu'
    ```
 
-1. Apply system level dotfiles
+1. Apply system level dotfiles with [sudo for nix command](https://github.com/kachick/dotfiles/commit/2e47c6655dc74a4a56495fdcbebb9d15b0b57313)
 
    ```bash
-   sudo -s "$(command -v nix)" run 'github:kachick/dotfiles#apply-system'
+   sudoc nix run 'github:kachick/dotfiles#apply-system'
    ```
 
 ### Podman on Ubuntu

--- a/config/tailscaled/defaults.conf
+++ b/config/tailscaled/defaults.conf
@@ -1,0 +1,10 @@
+# Upstream: https://github.com/tailscale/tailscale/blob/v1.80.3/cmd/tailscaled/tailscaled.defaults
+
+# Set the port to listen on for incoming VPN packets.
+# Remote nodes will automatically be informed about the new port number,
+# but you might want to configure this in order to set external firewall
+# settings.
+PORT="41641"
+
+# Extra flags you might want to pass to tailscaled.
+FLAGS=""

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -86,6 +86,8 @@
 
   pastel
 
+  tailscale # Frequently backported to stable channel
+
   # How to get the installed font names
   # fontconfig by nix: `fc-list : family style`
   # darwin: system_profiler SPFontsDataType

--- a/pkgs/apply-system/apply-system.bash
+++ b/pkgs/apply-system/apply-system.bash
@@ -1,0 +1,17 @@
+set -x
+
+if [ -e '/etc/NIXOS' ] || [ "$(uname)" != 'Linux' ]; then
+	echo 'You can use this script only for non NixOS Linux'
+	exit 2
+fi
+
+set -e
+
+# [home-manager installed OpenSSH disabled GSSAPI by default](https://github.com/kachick/dotfiles/issues/950).
+# So suppress `/etc/ssh/ssh_config line 53: Unsupported option "gssapiauthentication"` with following command
+chmod a-r /etc/ssh/ssh_config
+
+# Workaround for `-bash: warning: setlocale: LC_TIME: cannot change locale (en_DK.UTF-8): No such file or directory`
+localedef -f UTF-8 -i en_DK en_DK.UTF-8
+
+# Might be put code below which requires to inject Nix Store PATH

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -13,7 +13,7 @@ pkgs.writeShellApplication rec {
       mkdir --parents /etc/tmp # test
       mkdir --parents /etc/containers
       ln --symbolic --force '${../../config/containers/policy.json}' '/etc/containers/policy.json'
-      ln --symbolic --force '${pkgs.tailscale}/lib/systemd/system/tailscaled.service' /etc/systemd/system/
+      ln --symbolic --force '${pkgs.my.tailscaled-service}' '/etc/systemd/system/tailscaled.service'
       systemctl enable tailscaled.service
     '';
   runtimeInputs = with pkgs; [

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -10,7 +10,6 @@ pkgs.writeShellApplication rec {
   text =
     (builtins.readFile ./${name}.bash)
     + ''
-      mkdir --parents /etc/tmp # test
       mkdir --parents /etc/containers
       ln --symbolic --force '${../../config/containers/policy.json}' '/etc/containers/policy.json'
       ln --symbolic --force '${../../config/tailscaled/defaults.conf}' '/etc/default/tailscaled'

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+pkgs.writeShellApplication rec {
+  name = "apply-system";
+  # - Required to remove `errexit` for `||` operator
+  # Don't add `xtrace` here, it displays much long `export`. Add it in code if you want
+  bashOptions = [
+    "nounset"
+    "pipefail"
+  ];
+  text =
+    (builtins.readFile ./${name}.bash)
+    + ''
+      mkdir --parents /etc/tmp # test
+      mkdir --parents /etc/containers
+      ln --symbolic --force '${../../config/containers/policy.json}' '/etc/containers/policy.json'
+    '';
+  runtimeInputs = with pkgs; [
+    coreutils # `uname`, `ln`, `mkdir`
+  ];
+  meta = {
+    description = ''
+      System level activation script for non NixOS Linux.
+      Required to run with sudo. e.g. `sudo -s "$(command -v nix)" run .#apply-system`
+    '';
+  };
+}

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -13,6 +13,8 @@ pkgs.writeShellApplication rec {
       mkdir --parents /etc/tmp # test
       mkdir --parents /etc/containers
       ln --symbolic --force '${../../config/containers/policy.json}' '/etc/containers/policy.json'
+      ln --symbolic --force '${pkgs.tailscale}/lib/systemd/system/tailscaled.service' /etc/systemd/system/
+      systemctl enable tailscaled.service
     '';
   runtimeInputs = with pkgs; [
     coreutils # `uname`, `ln`, `mkdir`

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -23,7 +23,7 @@ pkgs.writeShellApplication rec {
   meta = {
     description = ''
       System level activation script for non NixOS Linux.
-      Required to run with sudo. e.g. `sudo -s "$(command -v nix)" run .#apply-system`
+      Required to run with sudo. e.g. `sudoc nix run .#apply-system`
     '';
   };
 }

--- a/pkgs/apply-system/package.nix
+++ b/pkgs/apply-system/package.nix
@@ -13,6 +13,7 @@ pkgs.writeShellApplication rec {
       mkdir --parents /etc/tmp # test
       mkdir --parents /etc/containers
       ln --symbolic --force '${../../config/containers/policy.json}' '/etc/containers/policy.json'
+      ln --symbolic --force '${../../config/tailscaled/defaults.conf}' '/etc/default/tailscaled'
       ln --symbolic --force '${pkgs.my.tailscaled-service}' '/etc/systemd/system/tailscaled.service'
       systemctl enable tailscaled.service
     '';

--- a/pkgs/tailscaled-service/package.nix
+++ b/pkgs/tailscaled-service/package.nix
@@ -1,0 +1,25 @@
+{
+  stdenvNoCC,
+  gnused,
+  installShellFiles,
+  tailscale,
+  ...
+}:
+stdenvNoCC.mkDerivation {
+  # https://github.com/NixOS/nixpkgs/issues/23099#issuecomment-964024407
+  dontUnpack = true;
+  name = "tailscaled-service";
+  postInstall = ''
+    sed '/\[Service\]/a EnvironmentFile=/etc/default/tailscaled' <'${tailscale}/lib/systemd/system/tailscaled.service' > ./tailscaled.service
+    install -D -m0444 -t $out/lib/systemd/system ./tailscaled.service
+  '';
+  nativeBuildInputs = [
+    gnused
+    installShellFiles
+  ];
+  meta = {
+    description = ''
+      Revert https://github.com/NixOS/nixpkgs/commit/503caab7765f31d18bce7fa58b26d447bc413c17#diff-be05f1b8ce13345e8991a5ee802268e588cc6f10fd4d5fcc62c6c1300bd97896R36 for non NixOS use
+    '';
+  };
+}

--- a/pkgs/tailscaled-service/package.nix
+++ b/pkgs/tailscaled-service/package.nix
@@ -1,25 +1,10 @@
-{
-  stdenvNoCC,
-  gnused,
-  installShellFiles,
-  tailscale,
-  ...
-}:
-stdenvNoCC.mkDerivation {
-  # https://github.com/NixOS/nixpkgs/issues/23099#issuecomment-964024407
-  dontUnpack = true;
-  name = "tailscaled-service";
-  postInstall = ''
-    sed '/\[Service\]/a EnvironmentFile=/etc/default/tailscaled' <'${tailscale}/lib/systemd/system/tailscaled.service' > ./tailscaled.service
-    install -D -m0444 -t $out/lib/systemd/system ./tailscaled.service
-  '';
-  nativeBuildInputs = [
-    gnused
-    installShellFiles
+{ substitute, tailscale }:
+substitute {
+  src = "${tailscale}/lib/systemd/system/tailscaled.service";
+  # Revert https://github.com/NixOS/nixpkgs/commit/503caab7765f31d18bce7fa58b26d447bc413c17#diff-be05f1b8ce13345e8991a5ee802268e588cc6f10fd4d5fcc62c6c1300bd97896R36 for non NixOS use
+  substitutions = [
+    "--replace"
+    "[Service]\nExecStart="
+    "[Service]\nEnvironmentFile=/etc/default/tailscaled\nExecStart="
   ];
-  meta = {
-    description = ''
-      Revert https://github.com/NixOS/nixpkgs/commit/503caab7765f31d18bce7fa58b26d447bc413c17#diff-be05f1b8ce13345e8991a5ee802268e588cc6f10fd4d5fcc62c6c1300bd97896R36 for non NixOS use
-    '';
-  };
 }


### PR DESCRIPTION
Resolves GH-1101

* [x] Implement system level initializer for non NixOS Linux
* [x] Patch tailscale package for non NixOS use
* [x] Install tailscaled.defaults for /etc/default/tailscaled
* [x] Add alias to run `sudo "$(command -v nix)" run` - 2e47c6655dc74a4a56495fdcbebb9d15b0b57313
* [x] Add test in CI
* [x] Remove debugging code

---

Supported environments

env | scoped in this PR | expected to be worked
----|------------|------------
NixOS | ❌ | ✅ 
non NixOS Linux | ✅ | ✅ 
WSL2 | ✅ | ✅ 
lima | ✅ | ✅ 
containers | ❌ | ❔ 
Windows | ❌ | ✅ 
darwin | ❌ | ✅ 