### PR TITLE
Fix unstable WiFi on NixOS installed laptop

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -28,7 +28,7 @@
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "24.11"; # Did you read the comment?
 
-  # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
+  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -28,7 +28,7 @@
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "24.11"; # Did you read the comment?
 
-  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant
+  # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -28,7 +28,7 @@
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "24.11"; # Did you read the comment?
 
-  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant
+  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Should keep for stable WiFi even if enabling networkmanager
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
@@ -39,7 +39,10 @@
     enable = true;
 
     # Avoiding conflict with wpa_supplicant
-    # Because of only using networkmanager does not fix stable WiFi on laptop even if using lwd for the backend
+    # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
+    # Then it made much of these logs
+    # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
+    # You can get the interface-name name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
     unmanaged = [
       "except:interface-name:wlp3s0"
     ];

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -42,10 +42,15 @@
     # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
     # Then it made much of these logs
     # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
+    #
     # You can get the interface-name name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
-    unmanaged = [
-      "except:interface-name:wlp3s0"
-    ];
+    # Set it in each host.
+    #
+    # For example
+    #
+    # unmanaged = [
+    #   "except:interface-name:wlp3s0"
+    # ];
   };
 
   # TODO: Reconsider to set UTC for servers

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -38,11 +38,13 @@
   networking.networkmanager = {
     enable = true;
 
-    # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix#L261-L289
-    wifi = {
-      # https://github.com/kachick/dotfiles/issues/663#issuecomment-2262189168
-      powersave = false;
-    };
+    # Avoiding conflict with wpa_supplicant
+    # Because of only using networkmanager does not fix stable WiFi on laptop even if using lwd for the backend
+    unmanaged = [
+      "*"
+      "except:type:wwan"
+      "except:type:gsm"
+    ];
   };
 
   # TODO: Reconsider to set UTC for servers

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -28,28 +28,9 @@
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "24.11"; # Did you read the comment?
 
-  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Should keep for stable WiFi even if enabling networkmanager
-
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
-
-  # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix
-  networking.networkmanager = {
-    enable = true;
-
-    # Avoiding conflict with wpa_supplicant
-    # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
-    # Then it made much of these logs
-    # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
-    #
-    # You can get the interface-name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
-    # Set it in each host.
-    #
-    # unmanaged = [
-    #   "except:interface-name:wlp3s0"
-    # ];
-  };
 
   # TODO: Reconsider to set UTC for servers
   time.timeZone = "Asia/Tokyo";

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -41,9 +41,7 @@
     # Avoiding conflict with wpa_supplicant
     # Because of only using networkmanager does not fix stable WiFi on laptop even if using lwd for the backend
     unmanaged = [
-      "*"
-      "except:type:wwan"
-      "except:type:gsm"
+      "except:interface-name:wlp3s0"
     ];
   };
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -38,12 +38,8 @@
   networking.networkmanager = {
     enable = true;
 
-    # Fixing unstable WiFi on laptop. See GH-663 for detail
     # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix#L261-L289
     wifi = {
-      # https://www.reddit.com/r/NixOS/comments/ikjpyb/wifi_network_manager_vs_wpa_supplicant/
-      # https://nixos.wiki/wiki/Iwd
-      backend = "iwd";
       # https://github.com/kachick/dotfiles/issues/663#issuecomment-2262189168
       powersave = false;
     };

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -43,10 +43,8 @@
     # Then it made much of these logs
     # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
     #
-    # You can get the interface-name name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
+    # You can get the interface-name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
     # Set it in each host.
-    #
-    # For example
     #
     # unmanaged = [
     #   "except:interface-name:wlp3s0"

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -38,8 +38,12 @@
   networking.networkmanager = {
     enable = true;
 
+    # Fixing unstable WiFi on laptop. See GH-663 for detail
     # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix#L261-L289
     wifi = {
+      # https://www.reddit.com/r/NixOS/comments/ikjpyb/wifi_network_manager_vs_wpa_supplicant/
+      # https://nixos.wiki/wiki/Iwd
+      backend = "iwd";
       # https://github.com/kachick/dotfiles/issues/663#issuecomment-2262189168
       powersave = false;
     };

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -30,7 +30,7 @@
     };
   };
 
-  # `wpa_gui`, `wpa_cli`
+  # `wpa_cli`. I don't know what is the `wpa_gui`
   networking.wireless.userControlled.enable = true;
 
   i18n = {

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -18,10 +18,10 @@
       description = "An admin";
       extraGroups = [
         "networkmanager"
-        "wheel" # WiFi
-        "input" # Finger print in GDM
+        "wheel"
+        "input" # For finger print in GDM
         "scanner"
-        "lp" # Scanner
+        "lp" # For scanner
       ];
       packages = [
         # Don't install unfree packages such as spotify.
@@ -29,9 +29,6 @@
       ];
     };
   };
-
-  # `wpa_gui`, `wpa_cli`
-  networking.wireless.userControlled.enable = true;
 
   i18n = {
     # GNOME respects this, I don't know how to realize it only via home-manager

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -18,10 +18,10 @@
       description = "An admin";
       extraGroups = [
         "networkmanager"
-        "wheel"
-        "input" # For finger print in GDM
+        "wheel" # WiFi
+        "input" # Finger print in GDM
         "scanner"
-        "lp" # For scanner
+        "lp" # Scanner
       ];
       packages = [
         # Don't install unfree packages such as spotify.
@@ -29,6 +29,9 @@
       ];
     };
   };
+
+  # `wpa_gui`, `wpa_cli`
+  networking.wireless.userControlled.enable = true;
 
   i18n = {
     # GNOME respects this, I don't know how to realize it only via home-manager

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,5 +1,24 @@
 { lib, pkgs, ... }:
 {
+  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Should keep for stable WiFi even if enabling networkmanager
+
+  # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix
+  networking.networkmanager = {
+    enable = true;
+
+    # Avoiding conflict with wpa_supplicant
+    # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
+    # Then it made much of these logs
+    # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
+    #
+    # You can get the interface-name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
+    # Set it in each host.
+    #
+    # unmanaged = [
+    #   "except:interface-name:wlp3s0"
+    # ];
+  };
+
   services.udev = {
     enable = true;
     # Settings keyremap in raw layer than X. See GH-784 and GH-963 for background. And see https://github.com/kachick/dotfiles/wiki/Key-Remapper for the guide

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -22,6 +22,12 @@
 
   services.xserver.videoDrivers = [ "amdgpu" ];
 
+  networking.networkmanager = {
+    unmanaged = [
+      "except:interface-name:wlp2s0"
+    ];
+  };
+
   # Required to reboot if you want to apply changes
   # Prevent GH-894
   # https://askubuntu.com/a/1446653

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -24,6 +24,12 @@
 
   services.xserver.videoDrivers = [ "amdgpu" ];
 
+  networking.networkmanager = {
+    unmanaged = [
+      "except:interface-name:wlp3s0"
+    ];
+  };
+
   services.udev.extraHwdb = lib.mkAfter ''
     evdev:name:AT Translated Set 2 keyboard:*
       KEYBOARD_KEY_3a=leftctrl # original: capslock


### PR DESCRIPTION
- **Enable wpa_supplicant**
- **Revert "Enable wpa_supplicant"**
- **Use iwd for the networkmanager backend**

Attempt to fix GH-663 again
