### PR TITLE
Bump Linux Kernel to 6.13 for fixing unstable RTL8852CE

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -4,6 +4,7 @@
 
 {
   pkgs,
+  lib,
   overlays,
   ...
 }:
@@ -50,7 +51,7 @@
     services.systemd-suspend.environment = {
       # Apply workaround as https://github.com/systemd/systemd/issues/33083#issuecomment-2142473011 to fix GH-959
       # TODO: Check again after systemd 257 or later. At least updating to nixos-25.05
-      SYSTEMD_SLEEP_FREEZE_USER_SESSIONS = "false";
+      SYSTEMD_SLEEP_FREEZE_USER_SESSIONS = lib.mkDefault "false";
     };
   };
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -131,6 +131,7 @@
 
       cyme
       lshw
+      pciutils # `lspci`
 
       # Don't use `buildFHSEnv` even through want to apply LSP smart. See GH-809
       unstable.zed-editor

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -6,6 +6,9 @@
   networking.networkmanager = {
     enable = true;
 
+    # If your WiFi is unstable, you should check the driver support for your device
+    # You can get the adapter name with `lspci`
+
     # Avoiding conflict with wpa_supplicant
     # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
     # Then it made much of these logs

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -24,21 +24,24 @@
   boot.extraModprobeConfig = ''
     options rtw89_pci disable_clkreq=y disable_aspm_l1=y disable_aspm_l1ss=y
   '';
-  boot.kernelPatches = [
-    {
-      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
-      name = "enable-rtw89_8852ce-config";
-      patch = null;
-      # Also requires RTW89 first. And the ancsetors... https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
-      # Can I set these more simply?
-      extraConfig = ''
-        CFG80211 y
-        MAC80211 y
-        RTW89 y
-        RTW89_8852CE y
-      '';
-    }
-  ];
+  # boot.kernelPatches = [
+  #   {
+  #     # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
+  #     name = "enable-rtw89_8852ce-config";
+  #     patch = null;
+  #     # Also requires RTW89 first. And the ancsetors... https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
+  #     # Can I set these more simply?
+  #     extraConfig = ''
+  #       CFG80211 y
+  #       MAC80211 y
+  #       RTW89 y
+  #       RTW89_8852CE y
+  #     '';
+  #   }
+  # ];
+
+  # https://github.com/NixOS/nixpkgs/issues/163586
+  hardware.enableRedistributableFirmware = true;
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -16,22 +16,19 @@
   #   - https://github.com/torvalds/linux/commit/0e5210217768625b43f099bcaafe627b098655d5
   #   - https://github.com/torvalds/linux/commit/1f3de77752a7bf0d1beb44603f048eb46948b9fe
   # TODO: Remove this customization since using nixos-25.05
-  boot.kernelPackages = pkgs.linuxPackages_latest;
-  # boot.kernelPatches = [
-  #   {
-  #     # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
-  #     name = "enable-rtw89_8852ce-config";
-  #     patch = null;
-  #     # Also requires RTW89 first. And the ancsetors... https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
-  #     # Can I set these more simply?
-  #     extraConfig = ''
-  #       MAC80211 y
-  #       CFG80211 y
-  #       RTW89 y
-  #       RTW89_8852CE y
-  #     '';
-  #   }
-  # ];
+  boot.kernelPackages = pkgs.linuxPackages_6_13;
+  boot.kernelPatches = [
+    {
+      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
+      name = "enable-rtw89_8852ce-config";
+      patch = null;
+      # Also requires RTW89 first. https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
+      extraConfig = ''
+        RTW89 y
+        RTW89_8852CE y
+      '';
+    }
+  ];
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -17,6 +17,16 @@
   #   - https://github.com/torvalds/linux/commit/1f3de77752a7bf0d1beb44603f048eb46948b9fe
   # TODO: Remove this customization since using nixos-25.05
   boot.kernelPackages = pkgs.linuxPackages_6_13;
+  boot.kernelPatches = [
+    {
+      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
+      name = "enable-rtw89_8852ce-config";
+      patch = null;
+      extraConfig = ''
+        RTW89_8852CE y
+      '';
+    }
+  ];
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -24,6 +24,21 @@
   boot.extraModprobeConfig = ''
     options rtw89_pci disable_clkreq=y disable_aspm_l1=y disable_aspm_l1ss=y
   '';
+  boot.kernelPatches = [
+    {
+      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
+      name = "enable-rtw89_8852ce-config";
+      patch = null;
+      # Also requires RTW89 first. And the ancsetors... https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
+      # Can I set these more simply?
+      extraConfig = ''
+        CFG80211 y
+        MAC80211 y
+        RTW89 y
+        RTW89_8852CE y
+      '';
+    }
+  ];
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -22,7 +22,9 @@
       # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
       name = "enable-rtw89_8852ce-config";
       patch = null;
+      # Also requires RTW89 first. https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
       extraConfig = ''
+        RTW89 y
         RTW89_8852CE y
       '';
     }

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -16,19 +16,22 @@
   #   - https://github.com/torvalds/linux/commit/0e5210217768625b43f099bcaafe627b098655d5
   #   - https://github.com/torvalds/linux/commit/1f3de77752a7bf0d1beb44603f048eb46948b9fe
   # TODO: Remove this customization since using nixos-25.05
-  boot.kernelPackages = pkgs.linuxPackages_6_13;
-  boot.kernelPatches = [
-    {
-      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
-      name = "enable-rtw89_8852ce-config";
-      patch = null;
-      # Also requires RTW89 first. https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
-      extraConfig = ''
-        RTW89 y
-        RTW89_8852CE y
-      '';
-    }
-  ];
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+  # boot.kernelPatches = [
+  #   {
+  #     # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
+  #     name = "enable-rtw89_8852ce-config";
+  #     patch = null;
+  #     # Also requires RTW89 first. And the ancsetors... https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
+  #     # Can I set these more simply?
+  #     extraConfig = ''
+  #       MAC80211 y
+  #       CFG80211 y
+  #       RTW89 y
+  #       RTW89_8852CE y
+  #     '';
+  #   }
+  # ];
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 {
   networking.hostName = "moss";
@@ -11,6 +11,12 @@
     ./hardware-configuration.nix
     ./fingerprint.nix
   ];
+
+  # Use 6.13 or higher to apply 2 commits for using RTL8852CE
+  #   - https://github.com/torvalds/linux/commit/0e5210217768625b43f099bcaafe627b098655d5
+  #   - https://github.com/torvalds/linux/commit/1f3de77752a7bf0d1beb44603f048eb46948b9fe
+  # TODO: Remove this customization since using nixos-25.05
+  boot.kernelPackages = pkgs.linuxPackages_6_13;
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -18,9 +18,11 @@
   # TODO: Remove this customization since using nixos-25.05
   boot.kernelPackages = pkgs.linuxPackages_6_13;
   # https://wiki.archlinux.org/title/Network_configuration/Wireless
+  # https://github.com/lwfinger/rtw89/blob/d1fced1b8a741dc9f92b47c69489c24385945f6e/README.md#L122-L181
   # https://github.com/NixOS/nixos-hardware/blob/380ed15bcd6440606c6856db44a99140d422b46f/lenovo/yoga/6/13ALC6/default.nix#L20-L23
+  # https://bugs.launchpad.net/ubuntu/+source/linux-firmware/+bug/1971656
   boot.extraModprobeConfig = ''
-    options rtw89_pci disable_aspm_l1=y disable_aspm_l1ss
+    options rtw89_pci disable_clkreq=y disable_aspm_l1=y disable_aspm_l1ss=y
   '';
 
   # Apply better fonts for non X consoles

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -28,6 +28,13 @@
     configurationLimit = 10;
   };
 
+  systemd = {
+    services.systemd-suspend.environment = {
+      # TODO: Remove this customization since using nixos-25.05
+      SYSTEMD_SLEEP_FREEZE_USER_SESSIONS = "true";
+    };
+  };
+
   services.xserver.videoDrivers = [ "amdgpu" ];
 
   networking.networkmanager = {

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -17,18 +17,11 @@
   #   - https://github.com/torvalds/linux/commit/1f3de77752a7bf0d1beb44603f048eb46948b9fe
   # TODO: Remove this customization since using nixos-25.05
   boot.kernelPackages = pkgs.linuxPackages_6_13;
-  boot.kernelPatches = [
-    {
-      # https://github.com/torvalds/linux/blob/88d324e69ea9f3ae1c1905ea75d717c08bdb8e15/drivers/net/wireless/realtek/rtw89/Kconfig#L87-L96
-      name = "enable-rtw89_8852ce-config";
-      patch = null;
-      # Also requires RTW89 first. https://github.com/NixOS/nixpkgs/issues/82951#issuecomment-602031597
-      extraConfig = ''
-        RTW89 y
-        RTW89_8852CE y
-      '';
-    }
-  ];
+  # https://wiki.archlinux.org/title/Network_configuration/Wireless
+  # https://github.com/NixOS/nixos-hardware/blob/380ed15bcd6440606c6856db44a99140d422b46f/lenovo/yoga/6/13ALC6/default.nix#L20-L23
+  boot.extraModprobeConfig = ''
+    options rtw89_pci disable_aspm_l1=y disable_aspm_l1ss
+  '';
 
   # Apply better fonts for non X consoles
   # https://github.com/NixOS/nixpkgs/issues/219239


### PR DESCRIPTION
- **Bump Linux Kernel to 6.13 in moss to support RTL8852CE**
- **Install pciutils for making it possible to use `lspci`**

Attempt to fix GH-663 again
