### PR TITLE
Drop workarounds about unstable WiFi since replaced RTL8852CE with AX210NGW

### DIFF
--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -1,34 +1,13 @@
 { lib, pkgs, ... }:
 {
-  networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Should keep for stable WiFi even if enabling networkmanager
+  # networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Bascically prefer networkmanager, enable this if unstable
 
   # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix
   networking.networkmanager = {
     enable = true;
 
-    # If your WiFi is unstable, you should check the driver support for your device
-    # You can get the adapter name with `lspci`
-
-    # Avoiding conflict with wpa_supplicant
-    # Because of only using networkmanager or using lwd for backend made unstable WiFi on laptop
-    # Then it made much of these logs
-    # wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by ...
-    #
-    # You can get the interface-name with `iw dev`. ref: https://wiki.archlinux.org/title/Network_configuration/Wireless#Get_the_name_of_the_interface
-    # Set it in each host.
-    #
-    # unmanaged = [
-    #   "except:interface-name:wlp3s0"
-    # ];
-
     # TIPS: If you are debugging, dmesg with ctime/iso will display incorrect timestamp
     # Then `journalctl --dmesg --output=short-iso --since='1 hour ago' --follow` might be useful
-
-    # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix#L261-L289
-    wifi = {
-      # https://github.com/kachick/dotfiles/issues/663#issuecomment-2262189168
-      powersave = false;
-    };
   };
 
   services.udev = {

--- a/nixos/hosts/algae/default.nix
+++ b/nixos/hosts/algae/default.nix
@@ -22,12 +22,6 @@
 
   services.xserver.videoDrivers = [ "amdgpu" ];
 
-  networking.networkmanager = {
-    unmanaged = [
-      "except:interface-name:wlp2s0"
-    ];
-  };
-
   # Required to reboot if you want to apply changes
   # Prevent GH-894
   # https://askubuntu.com/a/1446653

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 {
+  # ThinkPad E14 Gen 5 (AMD),
+  # but replaced unstable RTL8852CE with AX210NGW. See GH-663
   networking.hostName = "moss";
 
   imports = [

--- a/nixos/hosts/moss/default.nix
+++ b/nixos/hosts/moss/default.nix
@@ -24,12 +24,6 @@
 
   services.xserver.videoDrivers = [ "amdgpu" ];
 
-  networking.networkmanager = {
-    unmanaged = [
-      "except:interface-name:wlp3s0"
-    ];
-  };
-
   services.udev.extraHwdb = lib.mkAfter ''
     evdev:name:AT Translated Set 2 keyboard:*
       KEYBOARD_KEY_3a=leftctrl # original: capslock


### PR DESCRIPTION
- **Remove workarounds about unstable WiFi**
- **Clarify device info as a comment**

Resolves GH-663
Closes GH-1132
