### PR TITLE
Install chawan on darwin

### DIFF
--- a/home-manager/linux.nix
+++ b/home-manager/linux.nix
@@ -42,14 +42,10 @@
 
         tailscale # Frequently backported to stable channel
 
-        # Keybindigs: https://git.sr.ht/~bptato/chawan/tree/master/item/res/config.toml
-        chawan # `cha`
-
         shellcheck
         shfmt
       ])
       ++ (with pkgs.my; [
-        renmark # Depend on chawan
         rclone-list-mounted
         rclone-mount
         rclone-fzf

--- a/home-manager/packages.nix
+++ b/home-manager/packages.nix
@@ -84,6 +84,10 @@
   ruby_3_4
   _7zz # `7zz` - 7zip. Command is not 7zip.
 
+  # Keybindigs: https://git.sr.ht/~bptato/chawan/tree/master/item/res/config.toml
+  # Requiring unstable to apply https://github.com/nixos/nixpkgs/pull/394941
+  unstable.chawan # `cha`
+
   pastel
 
   # How to get the installed font names
@@ -114,4 +118,5 @@
   updeps
   bench_shells
   preview
+  renmark
 ])

--- a/pkgs/renmark/package.nix
+++ b/pkgs/renmark/package.nix
@@ -7,7 +7,7 @@ pkgs.writeShellApplication rec {
   #
   # After several candidates, I think this combination is the best for now.
   runtimeInputs = with pkgs; [
-    chawan
+    unstable.chawan
     comrak
   ];
   meta.description = "RENder MARkdown in terminal. See GH-740";


### PR DESCRIPTION
Backport https://github.com/NixOS/nixpkgs/compare/48255b201cdfc7b7f2e27cac45265553b00f99c1...e28cc0e6eb559a040aeba8835e701b2ddf47cf33

It can be used since GH-1152
