### PR TITLE
Update forked home-manager 24.11 channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,16 +39,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1737954034,
-        "narHash": "sha256-TbjPf48Z85zgOZjBXLmx+elczAUM7c/Ik7oTDcZc6mY=",
+        "lastModified": 1746706583,
+        "narHash": "sha256-SMT4U6SFwpYtM0KjzBZYyX6DOR6aFbYxpCdU0pxJMHM=",
         "owner": "kachick",
         "repo": "home-manager",
-        "rev": "f33926dadd874bb4e7b46e5ee9bb5102842b6665",
+        "rev": "1eacbedb191a5be5c3db8acec7792e212cf148a5",
         "type": "github"
       },
       "original": {
         "owner": "kachick",
-        "ref": "release-24.11",
+        "ref": "release-24.11.kachick.2025-05-08",
         "repo": "home-manager",
         "type": "github"
       }
@@ -60,16 +60,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1737954034,
-        "narHash": "sha256-TbjPf48Z85zgOZjBXLmx+elczAUM7c/Ik7oTDcZc6mY=",
+        "lastModified": 1746706583,
+        "narHash": "sha256-SMT4U6SFwpYtM0KjzBZYyX6DOR6aFbYxpCdU0pxJMHM=",
         "owner": "kachick",
         "repo": "home-manager",
-        "rev": "f33926dadd874bb4e7b46e5ee9bb5102842b6665",
+        "rev": "1eacbedb191a5be5c3db8acec7792e212cf148a5",
         "type": "github"
       },
       "original": {
         "owner": "kachick",
-        "ref": "release-24.11",
+        "ref": "release-24.11.kachick.2025-05-08",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,11 @@
     home-manager-linux = {
       # Using forked repository because of to apply https://github.com/nix-community/home-manager/pull/6357 in stable channel
       # See https://github.com/kachick/dotfiles/issues/1051 for detail
-      url = "github:kachick/home-manager/release-24.11";
+      url = "github:kachick/home-manager/release-24.11.kachick.2025-05-08";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager-darwin = {
-      url = "github:kachick/home-manager/release-24.11";
+      url = "github:kachick/home-manager/release-24.11.kachick.2025-05-08";
       inputs.nixpkgs.follows = "nixpkgs-darwin";
     };
     nixos-wsl = {


### PR DESCRIPTION
~Another try for https://github.com/kachick/dotfiles/issues/1164~ => It was another cause. I should progress this PR with another motivation

This change drops https://github.com/kachick/home-manager/commit/8c2afe4a0833a474890d30c9f0ced9f840b5f50e, it might be outdated code... (I can't remember the detail)