### PR TITLE
Rollback nixpkgs-24.11-darwin revision

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -55,7 +55,7 @@ jobs:
           {
             echo 'matrix<<JSON'
 
-            go run ./cmd/gen_matrix -event_name '${{ github.event_name }}' -paths "$CHANGED_PATHS"
+            echo '{"runner": ["ubuntu-24.04", "macos-13"]}'
 
             echo 'JSON'
           } | tee --append "$GITHUB_OUTPUT"

--- a/flake.lock
+++ b/flake.lock
@@ -114,17 +114,17 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1746399091,
-        "narHash": "sha256-q4yTsA+Wkukj/vEQlR7b7+33hWg5jzlvqAWUbZ+QZ5I=",
+        "lastModified": 1744492897,
+        "narHash": "sha256-qqKO4FOo/vPmNIaRPcLqwfudUlQ29iNdI1IbCZfjmxs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89140b70abfdc4c22481776e1c9df92fb631b173",
+        "rev": "86484f6076aac9141df2bfcddbf7dcfce5e0c6bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
+        "rev": "86484f6076aac9141df2bfcddbf7dcfce5e0c6bb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     # darwin does not have desirable channel for that purpose. See https://github.com/NixOS/nixpkgs/issues/107466
     edge-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/86484f6076aac9141df2bfcddbf7dcfce5e0c6bb"; # The revision is a snapshot of nixpkgs-24.11-darwin. Don't use the channel name to avoid triggering updater. Newer revisions seems not having crucial binary caches. See GH-1157 and GH-1164
     # https://github.com/nix-community/home-manager/blob/release-24.11/docs/manual/nix-flakes.md
     home-manager-linux = {
       # Using forked repository because of to apply https://github.com/nix-community/home-manager/pull/6357 in stable channel


### PR DESCRIPTION
- **Rollback nixpkgs-24.11-darwin channel**
- **Trigger macos-13 ci-home**

Another try for GH-1164. Partially reverting GH-1157
