### PR TITLE
trayscale: Fix missing icon in GNOME dash and wrong version display

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   home-manager:
-    timeout-minutes: 60
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:

--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -133,9 +133,7 @@ in
   # https://github.com/nix-community/home-manager/commit/4c8647b1ed35d0e1822c7997172786dfa18cd7da
   services.trayscale = {
     enable = true;
-    # Using latest would be better for this tool: https://github.com/DeedleFake/trayscale/issues/215#issuecomment-2905114976
-    # Keep in mind, this package has latest tailscale in the input. I think it is mostly okay, because of tailscale package is frequently backported to stable channel
-    package = pkgs.unstable.trayscale;
+    package = pkgs.patched.trayscale;
   };
 
   # GH-1228: Disable podman-desktop Telemetry

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -27,6 +27,7 @@
       # Test builds and push the binary cache from CI
       ++ (with pkgs.patched; [
         lima
+        trayscale
         signal-desktop
         shogihome
       ]);

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -71,7 +71,7 @@
           # https://github.com/DeedleFake/trayscale/blob/v0.18.3/dev.deedles.Trayscale.desktop
           postFixup = ''
             desktop-file-edit "$out/share/applications/dev.deedles.Trayscale.desktop" \
-              --set-key='startupWMClass' --set-value='dev.deedles.Trayscale'
+              --set-key='StartupWMClass' --set-value='dev.deedles.Trayscale'
           '';
         }
       );

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -70,7 +70,7 @@
           # Fix missing icon in GNOME dash
           # https://github.com/DeedleFake/trayscale/blob/v0.18.3/dev.deedles.Trayscale.desktop
           postFixup = ''
-            desktop-file-edit "$out/share/applications/trayscale.desktop" \
+            desktop-file-edit "$out/share/applications/dev.deedles.Trayscale.desktop" \
               --set-key='startupWMClass' --set-value='dev.deedles.Trayscale'
           '';
         }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -54,6 +54,8 @@
       );
 
       # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/tr/trayscale/package.nix
+      # Using latest would be better for this tool: https://github.com/DeedleFake/trayscale/issues/215#issuecomment-2905114976
+      # Keep in mind, this package has latest tailscale in the input. I think it is mostly okay, because of tailscale package is frequently backported to stable channel
       trayscale = prev.unstable.trayscale.overrideAttrs (
         finalAttrs: previousAttrs: {
           ldflags = [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -53,6 +53,27 @@
         }
       );
 
+      # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/tr/trayscale/package.nix
+      trayscale = prev.unstable.trayscale.overrideAttrs (
+        finalAttrs: previousAttrs: {
+          ldflags = [
+            "-s"
+            "-w"
+            # Apply https://github.com/DeedleFake/trayscale/commit/9948effb47c5e604e166d08799148656df24f729 to fix version display
+            "-X=deedles.dev/trayscale/internal/metadata.version=${finalAttrs.version}"
+          ];
+
+          nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ prev.unstable.desktop-file-utils ];
+
+          # Fix missing icon in GNOME dash
+          # https://github.com/DeedleFake/trayscale/blob/v0.18.3/dev.deedles.Trayscale.desktop
+          postFixup = ''
+            desktop-file-edit "$out/share/applications/trayscale.desktop" \
+              --set-key='startupWMClass' --set-value='dev.deedles.Trayscale'
+          '';
+        }
+      );
+
       # commandLineArgs is available since https://github.com/NixOS/nixpkgs/commit/6ad174a6dc07c7742fc64005265addf87ad08615
       signal-desktop = prev.unstable.signal-desktop.override {
         commandLineArgs = [


### PR DESCRIPTION
- **trayscale: Fix missing icon in GNOME dash and wrong version display**
- **Create binary cache of patched trayscale**
