### PR TITLE
Inline sudoc alias only in GHA to drop interactive mode

### DIFF
--- a/.github/workflows/ci-home.yml
+++ b/.github/workflows/ci-home.yml
@@ -59,7 +59,7 @@ jobs:
       # https://www.reddit.com/r/Nix/comments/1443k3o/comment/jr9ht5g/?utm_source=reddit&utm_medium=web2x&context=3
       - run: mkdir -p ~/.local/state/nix/profiles
       - run: nix run .#home-manager -- switch -b backup --flake '.#github-actions@${{ matrix.runner }}'
-      - run: zsh --interactive -c 'sudoc nix run ".#apply-system"'
+      - run: zsh -c 'sudo --preserve-env=PATH env nix run ".#apply-system"'
         if: runner.os == 'Linux'
       - name: Print some paths and versions
         run: |


### PR DESCRIPTION
Fixes GH-1180 again. Revised version of ac3ef7257c4d66e37ea103c84daf3388bf5c9168

Above commit broke CI, it's Murphy's Law :yum: 