### PR TITLE
Indicate lockkeys on GNOME bar

### DIFF
--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -200,6 +200,10 @@
         display-mode = 0;
       };
 
+      "org/gnome/shell/extensions/lockkeys" = {
+        style = "capslock";
+      };
+
       "org/gnome/mutter" = {
         experimental-features = [ "scale-monitor-framebuffer" ];
 

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -30,6 +30,7 @@
             dash-to-dock
             # Don't use third party themes. See https://github.com/do-not-theme/do-not-theme.github.io for detail
             # user-themes # the package name is not the `user-theme`, required `s` suffix
+            lock-keys
           ]
         );
 

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -235,6 +235,7 @@
       appindicator
       clipboard-history
       dash-to-dock
+      lock-keys
     ]);
 
   # https://askubuntu.com/a/88947


### PR DESCRIPTION
Even after dropping keyremappers in 0596bb9edb5674f1b4ee4a88af23eb55e7153a22, ThinkPad still be unstable by the capslock problems(GH-839, GH-1177).
And this device does not have the indicator on keyboard.
At least I would know it via GUI