### PR TITLE
Drop avahi and only use systemd-resolved for mDNS

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -170,13 +170,12 @@
     # Enable auto detect for wireless printers. CUPS does not support systemd-resolved
     # - https://github.com/apple/cups/issues/5452
     # - https://github.com/OpenPrinting/libcups/issues/81
-    enable = true; # If enabled, you should care the conflict with systemd-resolved
+    enable = false; # If enabled, you should care the conflict with systemd-resolved
 
-    # Make sure disabling mDNS in avahi to avoid conflict with systemd-resolved
+    # I don't know how to realize enabling DNS-SD but disable mDNS: https://wiki.archlinux.org/index.php?title=CUPS&diff=prev&oldid=806890
+    # Check the log with `journalctl -u systemd-resolved -u avahi-daemon -r`
     # I prefer systemd-resolved for mDNS use, because of enabling on Avahi makes much flaky resolutions
     # You can test it with: `avahi-resolve-host-name hostname.local` if enabled
-    nssmdns4 = false;
-    nssmdns6 = false;
   };
 
   ## systemd-resolved (Modern, not supported by CUPS)
@@ -187,7 +186,6 @@
     enable = true;
 
     # Enable mDNS(hostname.local). Consider to avoid conflict with Avahi
-    # My motivation come from: https://wiki.archlinux.org/index.php?title=CUPS&diff=prev&oldid=806890
     extraConfig = ''
       MulticastDNS=true
     '';

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -195,6 +195,17 @@
   # Avahi module has openFirewall, but resolved module does not have it
   networking.firewall.allowedUDPPorts = [ 5353 ];
 
+  # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/services/networking/networkmanager.nix
+  networking.networkmanager = {
+    enable = true;
+
+    dns = "systemd-resolved";
+    connectionConfig."connection.mdns" = 2;
+
+    # TIPS: If you are debugging, dmesg with ctime/iso will display incorrect timestamp
+    # Then `journalctl --dmesg --output=short-iso --since='1 hour ago' --follow` might be useful
+  };
+
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -188,6 +188,7 @@
     # Enable mDNS(hostname.local). Consider to avoid conflict with Avahi
     extraConfig = ''
       MulticastDNS=true
+      DNSStubListener=false
     '';
   };
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -193,6 +193,9 @@
     '';
   };
 
+  # Avahi module has openFirewall, but resolved module does not have it
+  networking.firewall.allowedUDPPorts = [ 5353 ];
+
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -184,6 +184,7 @@
   # Disabled by default. But ensures to disable MulticastDNS
   services.resolved = {
     enable = true;
+    llmnr = "false";
 
     # Enable mDNS(hostname.local). Consider to avoid conflict with Avahi
     extraConfig = ''

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -189,7 +189,6 @@
     # Enable mDNS(hostname.local). Consider to avoid conflict with Avahi
     extraConfig = ''
       MulticastDNS=true
-      DNSStubListener=false
     '';
   };
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -166,6 +166,7 @@
   # - https://github.com/NixOS/nixpkgs/issues/118628
   # - https://github.com/NixOS/nixpkgs/issues/412777
   # - https://github.com/NixOS/nixpkgs/issues/291108
+  # I don't know how to use both in NixOS likely https://wiki.archlinux.org/index.php?title=CUPS&diff=prev&oldid=806890
   services.avahi = {
     # Enable auto detect for wireless printers. CUPS does not support systemd-resolved
     # - https://github.com/apple/cups/issues/5452
@@ -179,6 +180,7 @@
   };
 
   ## systemd-resolved (Modern, not supported by CUPS)
+  # - Check the behavior with `resolvectl status`
   # - https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/system/boot/resolved.nix
   # - https://wiki.archlinux.org/title/Systemd-resolved
   # Disabled by default. But ensures to disable MulticastDNS

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -7,7 +7,7 @@
     enable = true;
 
     dns = "systemd-resolved";
-    connectionConfig."connection.mdns" = 1;
+    connectionConfig."connection.mdns" = 2;
 
     # TIPS: If you are debugging, dmesg with ctime/iso will display incorrect timestamp
     # Then `journalctl --dmesg --output=short-iso --since='1 hour ago' --follow` might be useful

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -2,17 +2,6 @@
 {
   # networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Bascically prefer networkmanager, enable this if unstable
 
-  # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/services/networking/networkmanager.nix
-  networking.networkmanager = {
-    enable = true;
-
-    dns = "systemd-resolved";
-    connectionConfig."connection.mdns" = 2;
-
-    # TIPS: If you are debugging, dmesg with ctime/iso will display incorrect timestamp
-    # Then `journalctl --dmesg --output=short-iso --since='1 hour ago' --follow` might be useful
-  };
-
   services.udev = {
     enable = true;
     # Settings keyremap in raw layer than X. See GH-784 and GH-963 for background. And see https://github.com/kachick/dotfiles/wiki/Key-Remapper for the guide

--- a/nixos/hardware.nix
+++ b/nixos/hardware.nix
@@ -2,9 +2,12 @@
 {
   # networking.wireless.enable = true; # Enables wireless support via wpa_supplicant. Bascically prefer networkmanager, enable this if unstable
 
-  # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/services/networking/networkmanager.nix
+  # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/services/networking/networkmanager.nix
   networking.networkmanager = {
     enable = true;
+
+    dns = "systemd-resolved";
+    connectionConfig."connection.mdns" = 1;
 
     # TIPS: If you are debugging, dmesg with ctime/iso will display incorrect timestamp
     # Then `journalctl --dmesg --output=short-iso --since='1 hour ago' --follow` might be useful


### PR DESCRIPTION
- **Completely disable Avahi to avoid conflict mDNS with systemd-resolved**
- **Adjust networkmanager**
- **Adjust support responder**
- **Disable DNSStubListener**
- **Disable LLMNR**
- **Clarify to allow 5353**

Follow more 1fc4d285f06e25bb778b291d5056ec91e834468e

ref: https://github.com/kachick/dotfiles/pull/1265
