### PR TITLE
Prefer $XDG_CONFIG_HOME/electron-flags.conf over patches for each package

### DIFF
--- a/config/electron/electron-flags.conf
+++ b/config/electron/electron-flags.conf
@@ -1,0 +1,4 @@
+--enable-features=WaylandWindowDecorations
+--ozone-platform-hint=auto
+--enable-wayland-ime=true
+--wayland-text-input-version=3

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -163,6 +163,11 @@
   xdg.configFile."nushell/config.nu".source = ../config/nushell/config.nu;
   xdg.configFile."nushell/unix_config.nu".source = ../config/nushell/unix_config.nu;
 
+  # I'm unsure why this file will work on NixOS. It is a customization on Arch and I coudn't find the patches on nixpkgs
+  # - https://github.com/electron/electron/issues/46473#issuecomment-2778637008
+  # - https://wiki.archlinux.org/title/Chromium#Native_Wayland_support
+  xdg.configFile."electron-flags.conf".source = ../config/electron/electron-flags.conf;
+
   xdg.dataFile."tmpbin/.keep".text = "";
 
   home.file.".hushlogin".text = "This file disables daily login message. Not depend on this text.";

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -13,8 +13,9 @@
 
 {
   home = {
-    packages =
-      (with pkgs.unstable; [
+    packages = (
+      with pkgs.unstable;
+      [
         # Disabling zed-editor because of it is most flaky in unstable channels.
         # If you want to use newer versions, consider to use upstream providing binary cache
         # See https://github.com/zed-industries/zed/issues/19937 for detail
@@ -23,12 +24,11 @@
         typos-lsp
         dprint
         # gnome-boxes # Omitting. I believe it is a core package of NixOS.
-      ])
-      # Test builds and push the binary cache from CI
-      ++ (with pkgs.patched; [
-        # lima # Enable when patched
-        signal-desktop
-        shogihome
-      ]);
+      ]
+    );
+    # # Test builds and push the binary cache from CI
+    # ++ (with pkgs.patched; [
+    #   # lima # Enable when patched
+    # ]);
   };
 }

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -176,7 +176,7 @@
       #   - https://github.com/YaLTeR/wl-clipboard-rs/issues/8#issuecomment-2396212342
       wl-clipboard # `wl-copy` and `wl-paste`
 
-      patched.signal-desktop
+      unstable.signal-desktop
 
       # Available since https://github.com/NixOS/nixpkgs/pull/409810
       unstable.bitsnpicas
@@ -186,6 +186,11 @@
       # Don't use unstable channel since nixos-25.05. It frequently backported to stable channel
       #   - https://github.com/NixOS/nixpkgs/commits/nixos-24.11/pkgs/applications/editors/vscode/vscode.nix
       # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/applications/editors/vscode/generic.nix#L207-L217
+      #
+      # AFAIK, vscode still requires `commandLineArgs` to specify custom flags. It didn't respect ~/.config/electron-flags.conf likely other electron apps
+      # This restriction might be related to
+      #   - https://github.com/archlinux/svntogit-community/commit/f9ec89f9e2845e90f9524b28b74daf33ceb699bb
+      #   - https://github.com/archlinux/svntogit-community/commit/c8bf3ae2e3deab793cb8e8544250ef943d14c85e
       (
         (vscode.override {
           # https://wiki.archlinux.org/title/Wayland#Electron
@@ -215,14 +220,7 @@
       # if you changed hostname and chrome doesn't run, see https://askubuntu.com/questions/476918/google-chrome-wont-start-after-changing-hostname
       # `rm -rf ~/.config/google-chrome/Singleton*`
       #
-      # https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/go/google-chrome/package.nix#L244-L253
-      (google-chrome.override {
-        # https://wiki.archlinux.org/title/Chromium#Native_Wayland_support
-        # Similar as https://github.com/nix-community/home-manager/blob/release-24.11/modules/programs/chromium.nix
-        commandLineArgs = [
-          "--wayland-text-input-version=3"
-        ];
-      })
+      google-chrome
 
       my.chrome-with-profile-by-name
     ])

--- a/nixos/desktop/game.nix
+++ b/nixos/desktop/game.nix
@@ -15,7 +15,7 @@
 
     ## shogihome does not provide configuration schema and ENV except CLI options, so manually setup the foollowing NNUE evaluation files for the engine
     # Related issue: https://github.com/sunfish-shogi/shogihome/issues/1017
-    patched.shogihome
+    unstable.shogihome
 
     my.tanuki-hao # NNUE evaluation file. It put under /run/current-system/sw/share/tanuki-hao/eval
   ];

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -52,38 +52,6 @@
       #     };
       #   }
       # );
-
-      # commandLineArgs is available since https://github.com/NixOS/nixpkgs/commit/6ad174a6dc07c7742fc64005265addf87ad08615
-      signal-desktop = prev.unstable.signal-desktop.override {
-        commandLineArgs = [
-          "--wayland-text-input-version=3"
-        ];
-      };
-
-      shogihome = prev.unstable.shogihome.overrideAttrs (
-        finalAttrs: previousAttrs: {
-          version = "1.25.0";
-
-          src = prev.fetchFromGitHub {
-            owner = "sunfish-shogi";
-            repo = "shogihome";
-            tag = "v${finalAttrs.version}";
-            hash = "sha256-Qa8ykN514Moc/PpBhD/X+mzfclQPp3yiriwTJCtmMA8=";
-          };
-
-          # Should manually override instead of replacing npmDepsHash
-          # https://discourse.nixos.org/t/npmdepshash-override-what-am-i-missing-please/50967/4?u=kachick
-          npmDeps = final.fetchNpmDeps {
-            inherit (finalAttrs) src;
-            name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
-            hash = "sha256-rcrj3dG96oNbmp3cXw1qRJPi1SZdBcG9paAShSfb/0E=";
-          };
-
-          commandLineArgs = [
-            "--wayland-text-input-version=3"
-          ];
-        }
-      );
     };
   })
 ]


### PR DESCRIPTION
To obtain help with official binary cache.
At least this way worked with signal-desktop and shogihome.
I don't know why this Arch way is also work on NixOS...
However definitely useful!

With this patch, shogime will be downgraded to previous 1.24.3.
However it will be immediately updated with next flake.lock updates.
