### PR TITLE
Prefer channels.nixos.org rather than GitHub in flake inputs

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -46,7 +46,7 @@ func main() {
 	linters := runner.Commands{
 		{Path: "shellcheck", Args: bashPaths},
 		{Path: "typos", Args: constants.GetTyposTargetedRoots()},
-		// Add selfup as `git ls-files | xargs nix run github:kachick/selfup/v1.2.0 -- list -check`. Consider https://github.com/kachick/dotfiles/issues/905 for use of pipe
+		// Add selfup as `git ls-files | xargs nix run github:kachick/selfup/v1.2.2 -- list -check`. Consider https://github.com/kachick/dotfiles/issues/905 for use of pipe
 	}
 
 	heavyOrTrivial := runner.Commands{

--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,15 @@
   "nodes": {
     "edge-nixpkgs": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
+        "lastModified": 1757808699,
+        "narHash": "sha256-rmyZ6B4DtU9MwkBSEf63NU4czFoM0budKcAtlhjaGEc=",
         "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre861038.c23193b943c6/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "flake-compat": {
@@ -98,34 +95,28 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757810152,
-        "narHash": "sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9a094440e02a699be5c57453a092a8baf569bdad",
-        "type": "github"
+        "lastModified": 1758109165,
+        "narHash": "sha256-ml/hYens3eJ04gXRqDCUqSit79qCcWgT5XUfm5PGNkk=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/25.05/nixos-25.05.809913.7ff837017c3b/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz"
       }
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
-        "type": "github"
+        "lastModified": 315532800,
+        "narHash": "sha256-rfjFby4ZFSt41iy7oRSTR9eEApHbpSz0O4Le1yMf2G4=",
+        "rev": "04389cd713308d659e275e5ad72732896a2f8d58",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/25.05-darwin/nixpkgs-darwin-25.05pre809917.04389cd71330/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-25.05-darwin/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,15 +11,21 @@
   };
 
   inputs = {
+    # Why prefer channels.nixos.org rather than GitHub?
+    #   - Avoid rate limit
+    #   - nixos.org distributing tar.xz is smaller than GitHUub's zip
+    #   - nixos.org distributing tar.xz might ensure stable binary caches
+    # See https://github.com/kachick/dotfiles/issues/1262#issuecomment-3302717297 for detail
+    #
     # Candidate channels
     #   - https://github.com/kachick/anylang-template/issues/17
     #   - https://discourse.nixos.org/t/differences-between-nix-channels/13998
     # How to update the revision
     #   - `nix flake update --commit-lock-file` # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake-update.html
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz";
     # darwin does not have desirable channel for that purpose. See https://github.com/NixOS/nixpkgs/issues/107466
-    edge-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-25.05-darwin";
+    edge-nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    nixpkgs-darwin.url = "https://channels.nixos.org/nixpkgs-25.05-darwin/nixexprs.tar.xz";
     home-manager-linux = {
       url = "github:nix-community/home-manager/release-25.05";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
- **Prefer channels.nixos.org rather than GitHub in flake inputs**
- **Selfup provides binary cache since 1.2.1**

Prevents https://github.com/kachick/dotfiles/issues/1262#issuecomment-3302879486 or Resolves GH-1262
