### PR TITLE
Prefer the gh command over curl to avoid hitting GitHub's API rate limit

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -15,14 +15,16 @@ jobs:
       # So simply uses the pre-built CLI here.
       - name: Download
         working-directory: ${{ runner.temp }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Prefer the gh command over curl to avoid hitting GitHub's API rate limit
         run: |
-          curl -OL 'https://github.com/gitleaks/gitleaks/releases/download/v${{ env.CLI_VERSION }}/gitleaks_${{ env.CLI_VERSION }}_linux_x64.tar.gz'
-          curl -OL 'https://github.com/gitleaks/gitleaks/releases/download/v${{ env.CLI_VERSION }}/gitleaks_${{ env.CLI_VERSION }}_checksums.txt'
+          gh release download '${{ env.CLI_VERSION }}' --skip-existing --repo gitleaks/gitleaks --pattern '*_linux_x64.*' --pattern '*_checksums.txt'
           sha256sum --check --ignore-missing gitleaks_${{ env.CLI_VERSION }}_checksums.txt
       - name: Install
         working-directory: ${{ runner.temp }}
         run: |
-          tar zxvf gitleaks_${{ env.CLI_VERSION }}_linux_x64.tar.gz
+          tar zxvf 'gitleaks_${{ env.CLI_VERSION }}_linux_x64.tar.gz'
           mkdir --parents /home/runner/.gitleaks/bin
           mv gitleaks /home/runner/.gitleaks/bin
           echo '/home/runner/.gitleaks/bin' >> $GITHUB_PATH


### PR DESCRIPTION
I have faced many curl errors while addressing https://github.com/kachick/dotfiles/pull/1281

It seems a similar problem such as https://github.com/kachick/dotfiles/pull/1275
