### PR TITLE
Backport mozc patch to fix Super key hijacking

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -85,7 +85,6 @@ jobs:
           # - macos-13 # Don't use macos-14 or later. macos-13 is the last runner of x86_64-darwin
         pname:
           - filen-rclone
-          - mozc
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     steps:

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -85,6 +85,7 @@ jobs:
           # - macos-13 # Don't use macos-14 or later. macos-13 is the last runner of x86_64-darwin
         pname:
           - filen-rclone
+          - mozc
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     steps:

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -30,6 +30,11 @@
       ++ [
         # pkgs.patched.pname
         # pkgs.patched.lima # Enable when patched
+      ]
+      # These packages are override original pname instead of adding new namespace. So required to build the binary cache here. I'm unsure how to run these in ci-nix
+      ++ [
+        pkgs.gnome-keyring
+        (with pkgs.ibus-engines; [ mozc ])
       ];
   };
 }

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -32,6 +32,9 @@
         # pkgs.patched.lima # Enable when patched
       ]
       # These packages are override original pname instead of adding new namespace. So required to build the binary cache here. I'm unsure how to run these in ci-nix
+      ++ [
+        pkgs.gnome-keyring
+      ]
       ++ (with pkgs.ibus-engines; [ mozc ]);
   };
 }

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -32,9 +32,6 @@
         # pkgs.patched.lima # Enable when patched
       ]
       # These packages are override original pname instead of adding new namespace. So required to build the binary cache here. I'm unsure how to run these in ci-nix
-      ++ [
-        pkgs.gnome-keyring
-      ]
       ++ (with pkgs.ibus-engines; [ mozc ]);
   };
 }

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -32,9 +32,10 @@
         # pkgs.patched.lima # Enable when patched
       ]
       # These packages are override original pname instead of adding new namespace. So required to build the binary cache here. I'm unsure how to run these in ci-nix
-      ++ [
-        pkgs.gnome-keyring
-      ]
+      # ++ [
+      #   # I don't know why this overriding will not work :<
+      #   pkgs.gnome-keyring
+      # ]
       ++ (with pkgs.ibus-engines; [ mozc ]);
   };
 }

--- a/home-manager/linux-ci.nix
+++ b/home-manager/linux-ci.nix
@@ -34,7 +34,7 @@
       # These packages are override original pname instead of adding new namespace. So required to build the binary cache here. I'm unsure how to run these in ci-nix
       ++ [
         pkgs.gnome-keyring
-        (with pkgs.ibus-engines; [ mozc ])
-      ];
+      ]
+      ++ (with pkgs.ibus-engines; [ mozc ]);
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,20 +28,7 @@
     # NOTE: This approcah might be wrong. See https://github.com/kachick/dotfiles/pull/1235/files#r2261225864 for detail
     gnome-keyring = prev.unstable.gnome-keyring;
 
-    # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
-    # The mozc package in nixpkgs often remains on old versions, primarily due to bazel dependency issues.
-    # However, the latest mozc(2.31.5712.102 or later) includes a crucial patch to fix the Super key hijacking.
-    mozc = prev.mozc.overrideAttrs (
-      finalAttrs: previousAttrs: {
-        patches = [
-          (prev.fetchpatch {
-            name = "GH-1277.patch";
-            url = "https://patch-diff.githubusercontent.com/raw/google/mozc/pull/1059.patch?full_index=1";
-            hash = "sha256-c67WPdvPDMxcduKOlD2z0M33HLVq8uO8jzJVQfBoxSY=";
-          })
-        ];
-      }
-    );
+    mozc = prev.patched.mozc;
   })
 
   (final: prev: {
@@ -86,6 +73,21 @@
             url = "https://github.com/google-gemini/gemini-cli/releases/download/v${finalAttrs.version}/gemini.js";
             hash = "sha256-gTd+uw5geR7W87BOiE6YmDDJ4AiFlYxbuLE2GWgg0kw=";
           };
+        }
+      );
+
+      # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
+      # The mozc package in nixpkgs often remains on old versions, primarily due to bazel dependency issues.
+      # However, the latest mozc(2.31.5712.102 or later) includes a crucial patch to fix the Super key hijacking.
+      mozc = prev.mozc.overrideAttrs (
+        finalAttrs: previousAttrs: {
+          patches = [
+            (prev.fetchpatch {
+              name = "GH-1277.patch";
+              url = "https://patch-diff.githubusercontent.com/raw/google/mozc/pull/1059.patch?full_index=1";
+              hash = "sha256-c67WPdvPDMxcduKOlD2z0M33HLVq8uO8jzJVQfBoxSY=";
+            })
+          ];
         }
       );
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,7 +28,7 @@
     # NOTE: This approcah might be wrong. See https://github.com/kachick/dotfiles/pull/1235/files#r2261225864 for detail
     gnome-keyring = prev.unstable.gnome-keyring;
 
-    mozc = final.patched.mozc;
+    mozc = prev.patched.mozc;
   })
 
   (final: prev: {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,7 +28,20 @@
     # NOTE: This approcah might be wrong. See https://github.com/kachick/dotfiles/pull/1235/files#r2261225864 for detail
     gnome-keyring = prev.unstable.gnome-keyring;
 
-    mozc = prev.patched.mozc;
+    # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
+    # The mozc package in nixpkgs often remains on old versions, primarily due to bazel dependency issues.
+    # However, the latest mozc(2.31.5712.102 or later) includes a crucial patch to fix the Super key hijacking.
+    mozc = prev.mozc.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        patches = [
+          (prev.fetchpatch {
+            name = "GH-1277.patch";
+            url = "https://patch-diff.githubusercontent.com/raw/google/mozc/pull/1059.patch?full_index=1";
+            hash = "sha256-c67WPdvPDMxcduKOlD2z0M33HLVq8uO8jzJVQfBoxSY=";
+          })
+        ];
+      }
+    );
   })
 
   (final: prev: {
@@ -73,21 +86,6 @@
             url = "https://github.com/google-gemini/gemini-cli/releases/download/v${finalAttrs.version}/gemini.js";
             hash = "sha256-gTd+uw5geR7W87BOiE6YmDDJ4AiFlYxbuLE2GWgg0kw=";
           };
-        }
-      );
-
-      # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
-      # The mozc package in nixpkgs often remains on old versions, primarily due to bazel dependency issues.
-      # However, the latest mozc(2.31.5712.102 or later) includes a crucial patch to fix the Super key hijacking.
-      mozc = prev.mozc.overrideAttrs (
-        finalAttrs: previousAttrs: {
-          patches = [
-            (prev.fetchpatch {
-              name = "GH-1277.patch";
-              url = "https://patch-diff.githubusercontent.com/raw/google/mozc/pull/1059.patch?full_index=1";
-              hash = "sha256-c67WPdvPDMxcduKOlD2z0M33HLVq8uO8jzJVQfBoxSY=";
-            })
-          ];
         }
       );
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -29,8 +29,8 @@
     gnome-keyring = prev.unstable.gnome-keyring;
 
     # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
-    # mozc package in nixpkgs is often stay old versions mainly caused by the bazel dependencies
-    # However the latest mozc(2.31.5712.102 or later) has crucial patch to fix hijacking Super key.
+    # The mozc package in nixpkgs often remains on old versions, primarily due to bazel dependency issues.
+    # However, the latest mozc(2.31.5712.102 or later) includes a crucial patch to fix the Super key hijacking.
     mozc = prev.mozc.overrideAttrs (
       finalAttrs: previousAttrs: {
         patches = [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,7 +28,7 @@
     # NOTE: This approcah might be wrong. See https://github.com/kachick/dotfiles/pull/1235/files#r2261225864 for detail
     gnome-keyring = prev.unstable.gnome-keyring;
 
-    mozc = prev.patched.mozc;
+    mozc = final.patched.mozc;
   })
 
   (final: prev: {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -27,6 +27,21 @@
     #
     # NOTE: This approcah might be wrong. See https://github.com/kachick/dotfiles/pull/1235/files#r2261225864 for detail
     gnome-keyring = prev.unstable.gnome-keyring;
+
+    # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/mo/mozc/package.nix
+    # mozc package in nixpkgs is often stay old versions mainly caused by the bazel dependencies
+    # However the latest mozc(2.31.5712.102 or later) has crucial patch to fix hijacking Super key.
+    mozc = prev.mozc.overrideAttrs (
+      finalAttrs: previousAttrs: {
+        patches = [
+          (prev.fetchpatch {
+            name = "GH-1277.patch";
+            url = "https://patch-diff.githubusercontent.com/raw/google/mozc/pull/1059.patch?full_index=1";
+            hash = "sha256-c67WPdvPDMxcduKOlD2z0M33HLVq8uO8jzJVQfBoxSY=";
+          })
+        ];
+      }
+    );
   })
 
   (final: prev: {


### PR DESCRIPTION
Fixes #1277

- **Backport mozc patch to avoid super key hijacking**
- **Attempt to build and push the binary cache**
