### PR TITLE
Clarify current state using upstream Nix

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -10,6 +10,7 @@ runs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@v20
       with:
+        determinate: false
         extra-conf: |
           accept-flake-config = true
     - name: Configure Cachix

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -34,7 +34,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@v20
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Print some dotfiles overviews
         shell: bash -eu -o pipefail {0}
         run: |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ nix eval --json 'github:kachick/dotfiles#homeConfigurations' --apply 'builtins.a
 1. Install [Nix](https://nixos.org/) package manager with [DeterminateSystems/nix-installer](https://github.com/DeterminateSystems/nix-installer) to enable [Flakes](https://nixos.wiki/wiki/Flakes) by default.
 
    ```bash
-   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix
    ```
 
 1. Make sure your user or one of the groups are listed in `trusted-users`


### PR DESCRIPTION
While I may switch to Determinate Nix in the future,
I am using this code to clarify the current state.

https://determinate.systems/blog/installer-dropping-upstream/

Preparation part for GH-1269
