### PR TITLE
Exclude non-essential packages from recovery ISO

### DIFF
--- a/home-manager/desktop.nix
+++ b/home-manager/desktop.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  osConfig,
   ...
 }:
 
@@ -29,9 +30,8 @@ let
     "firefox.desktop"
     # Chrome is heavy when open large PDF files
     "google-chrome.desktop"
-
-    "org.gnome.Papers.desktop"
-  ];
+  ]
+  ++ lib.optional (!(osConfig.profiles.recovery or false)) "org.gnome.Papers.desktop";
 
   terminalEmulator = [
     "com.mitchellh.ghostty.desktop"

--- a/home-manager/gnome.nix
+++ b/home-manager/gnome.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  osConfig,
+  ...
+}:
 
 {
   # https://github.com/nix-community/home-manager/blob/release-25.11/modules/misc/dconf.nix
@@ -42,8 +47,12 @@
           "google-chrome.desktop"
           "firefox.desktop"
           "signal.desktop"
+        ]
+        ++ lib.optionals (!(osConfig.profiles.recovery or false)) [
           "winboat.desktop"
           "io.gitlab.news_flash.NewsFlash.desktop"
+        ]
+        ++ [
           "org.gnome.Nautilus.desktop"
           "io.missioncenter.MissionCenter.desktop"
         ];
@@ -332,7 +341,7 @@
           let
             music = "3";
           in
-          [
+          lib.optionals (!(osConfig.profiles.recovery or false)) [
             "org.gnome.Rhythmbox3.desktop:${music}"
           ];
       };

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -135,88 +135,77 @@
 
   # If adding unstable packages here, you should also add it into home-manager/linux-ci.nix
   environment.systemPackages =
-    (with pkgs; [
-      firefox
+    (
+      with pkgs;
+      [
+        firefox
 
-      # https://github.com/NixOS/nixpkgs/issues/33282
-      xdg-user-dirs
+        # https://github.com/NixOS/nixpkgs/issues/33282
+        xdg-user-dirs
 
-      cyme
-      lshw
-      pciutils # `lspci`
-      smartmontools # `sudo smartctl -a /dev/nvme0n1`
-      nvme-cli # `sudo nvme id-ctrl /dev/nvme0n1`
+        cyme
+        lshw
+        pciutils # `lspci`
+        smartmontools # `sudo smartctl -a /dev/nvme0n1`
+        nvme-cli # `sudo nvme id-ctrl /dev/nvme0n1`
 
-      # - Don't use `buildFHSEnv` even through want to apply LSP smart. See GH-809
-      # - We can't trust any nixpkgs' channel for zed-editor package. Both stable and unstable are flaky.
-      #   See package-linux/darwin workflows for the dedicated building.
-      unstable.zed-editor
+        # - Don't use `buildFHSEnv` even through want to apply LSP smart. See GH-809
+        # - We can't trust any nixpkgs' channel for zed-editor package. Both stable and unstable are flaky.
+        #   See package-linux/darwin workflows for the dedicated building.
+        unstable.zed-editor
 
-      gdm-settings
-      desktop-file-utils # `desktop-file-validate`
+        gdm-settings
+        desktop-file-utils # `desktop-file-validate`
 
-      ghostty
+        ghostty
 
-      alacritty
+        alacritty
 
-      lapce # IME is not working on Windows, but stable even around IME on Wayland than vscode
+        lapce # IME is not working on Windows, but stable even around IME on Wayland than vscode
 
-      mission-center
+        mission-center
+      ]
+      ++ lib.optionals (!config.profiles.recovery) [
+        # Add LSP global for zed-editor. Prefer external package for helix
+        vscode-langservers-extracted
+        # bash-language-server # Don't use, less benefit and old in nixpkgs https://github.com/NixOS/nixpkgs/issues/374172
 
-      # Add LSP global for zed-editor. Prefer external package for helix
-      vscode-langservers-extracted
-      # bash-language-server # Don't use, less benefit and old in nixpkgs https://github.com/NixOS/nixpkgs/issues/374172
+        # gnome-music does not support flac.
 
-      # gnome-music does not support flac.
-      # tramhao/termusic and tsirysndr/music-player does not figure how to use.
-      rhythmbox
+        # tramhao/termusic and tsirysndr/music-player does not figure how to use.
+        rhythmbox
 
-      evtest # To debug keyremapper as GH-786
-      psmisc # e.g. `fuser -v /dev/input/event17` when want to know event17 is grabbed by which process
+        newsflash # `io.gitlab.news_flash.NewsFlash`
 
-      newsflash # `io.gitlab.news_flash.NewsFlash`
+        # calibre # Don't install calibre if possible. It has much of Python and JavaScript dependencies. And it sets the E-book reader for opening markdown files by default.
+        readest # ebook(epub) reader. Prefer this than unstable Alexandria and heavy calibre
 
-      # calibre # Don't install calibre if possible. It has much of Python and JavaScript dependencies. And it sets the E-book reader for opening markdown files by default.
-      readest # ebook(epub) reader. Prefer this than unstable Alexandria and heavy calibre
+        # Using unstable to test own patch: https://github.com/NixOS/nixpkgs/pull/463074
+        unstable.podman-desktop
 
-      gnome-tweaks # Maintained by GNOME org: https://gitlab.gnome.org/GNOME/gnome-tweaks
-      dconf-editor
+        # Install one of PDF reader to enable PDF thumbnails on nautilus.
+        # It should have `share/thumbnailers/`
+        # See https://github.com/NixOS/nixpkgs/issues/200714#issuecomment-1318003798 and https://github.com/NixOS/nixpkgs/issues/275046 for details
+        papers # PDF reader. Successor of evince. Slow, but the default in GNOME 49.
 
-      # Using unstable to test own patch: https://github.com/NixOS/nixpkgs/pull/463074
-      unstable.podman-desktop
+        # As signal, it heavyly relies on their service, the delay of waiting stable version does not make sense
+        unstable.signal-desktop
+      ]
+      ++ [
+        evtest # To debug keyremapper as GH-786
+        psmisc # e.g. `fuser -v /dev/input/event17` when want to know event17 is grabbed by which process
 
-      # Install one of PDF reader to enable PDF thumbnails on nautilus.
-      # It should have `share/thumbnailers/`
-      # See https://github.com/NixOS/nixpkgs/issues/200714#issuecomment-1318003798 and https://github.com/NixOS/nixpkgs/issues/275046 for details
-      papers # PDF reader. Successor of evince. Slow, but the default in GNOME 49.
+        gnome-tweaks # Maintained by GNOME org: https://gitlab.gnome.org/GNOME/gnome-tweaks
+        dconf-editor
 
-      gnome-epub-thumbnailer
+        gnome-epub-thumbnailer
 
-      loupe # image viewer
+        # Use unstable to wait https://github.com/CramBL/mdns-scanner/issues/88
+        unstable.mdns-scanner
 
-      contrast # Check two color contrast. Also using as a color-picker
-
-      # Clipboard
-      #
-      # Don't use clipcat, copyq for wayland problem
-      # Dont' use cliphist for electron problem: https://www.reddit.com/r/NixOS/comments/1d57zbj/problem_with_cliphist_and_electron_apps/
-      # Don't use clipse it made flickers on GNOME
-      #
-      # So prefer clipboard gnome extension except below tools
-      #
-      # Don't use `wl-clipboard-rs`, it doesn't work on GNOME.
-      #   - "Error: A required Wayland protocol (zwlr_data_control_manager_v1 version 2) is not supported by the compositor"
-      #   - https://github.com/YaLTeR/wl-clipboard-rs/issues/8#issuecomment-2396212342
-      wl-clipboard # `wl-copy` and `wl-paste`
-
-      # As signal, it heavyly relies on their service, the delay of waiting stable version does not make sense
-      unstable.signal-desktop
-
-      # Use unstable to wait https://github.com/CramBL/mdns-scanner/issues/88
-      unstable.mdns-scanner
-
-      local.chrome-with-profile-by-name
-    ])
+        local.chrome-with-profile-by-name
+      ]
+    )
     ++ (with pkgs.gnomeExtensions; [
       appindicator
       clipboard-history

--- a/nixos/desktop/font.nix
+++ b/nixos/desktop/font.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 {
   fonts = {
     enableDefaultPackages = true;
@@ -11,23 +16,31 @@
     # ```
     fontDir.enable = true;
 
-    packages = with pkgs; [
-      ibm-plex
-      plemoljp-nf
-      inconsolata
-      mplus-outline-fonts.githubRelease
-      # sarasa-gothic # Drop this because of the large filesize
+    packages =
+      with pkgs;
+      [
+        ibm-plex
+        plemoljp-nf
+        inconsolata
+        mplus-outline-fonts.githubRelease
+        # sarasa-gothic # Drop this because of the large filesize
 
-      # emoji
-      noto-fonts-color-emoji
-      twemoji-color-font
-      beedii
-
-      # Source Han family includes many definitions, useful for fallback
-      source-han-code-jp
-      source-han-sans
-      source-han-serif
-    ];
+        # emoji
+        noto-fonts-color-emoji
+        twemoji-color-font
+      ]
+      ++ lib.optional (!config.profiles.recovery) beedii
+      ++ (
+        if config.profiles.recovery then
+          [ noto-fonts-cjk-sans ]
+        else
+          [
+            # Source Han family includes many definitions, useful for fallback
+            source-han-code-jp
+            source-han-sans
+            source-han-serif
+          ]
+      );
 
     # Same as home-manager module?
     # https://github.com/nix-community/home-manager/issues/605

--- a/nixos/desktop/game.nix
+++ b/nixos/desktop/game.nix
@@ -1,20 +1,28 @@
-{ pkgs, ... }:
 {
-  environment.systemPackages = with pkgs; [
-    # Board Game
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  environment.systemPackages = lib.optionals (!config.profiles.recovery) (
+    with pkgs;
+    [
+      # Board Game
 
-    # Use latest to avoid update notifier (Might be better disabling it in nixpkgs)
-    unstable.vassal
+      # Use latest to avoid update notifier (Might be better disabling it in nixpkgs)
+      unstable.vassal
 
-    # Shogi
+      # Shogi
 
-    ## Install yaneuraou for each host with the optimized label if required
-    ## If installing at here, it should be "SSE2"
+      ## Install yaneuraou for each host with the optimized label if required
+      ## If installing at here, it should be "SSE2"
 
-    ## shogihome does not provide configuration schema and ENV except CLI options, so manually setup the foollowing NNUE evaluation files for the engine
-    # Related issue: https://github.com/sunfish-shogi/shogihome/issues/1017
-    unstable.shogihome
+      ## shogihome does not provide configuration schema and ENV except CLI options, so manually setup the foollowing NNUE evaluation files for the engine
+      # Related issue: https://github.com/sunfish-shogi/shogihome/issues/1017
+      unstable.shogihome
 
-    local.tanuki-hao # NNUE evaluation file. It put under /run/current-system/sw/share/tanuki-hao/eval
-  ];
+      local.tanuki-hao # NNUE evaluation file. It put under /run/current-system/sw/share/tanuki-hao/eval
+    ]
+  );
 }

--- a/nixos/desktop/vm.nix
+++ b/nixos/desktop/vm.nix
@@ -1,6 +1,11 @@
 # This file defines GUI VM management on NixOS desktop. See also lima related files in home-manager
 
-{ pkgs, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 {
   # Why not other candidates?
   #
@@ -15,17 +20,17 @@
 
   virtualisation.spiceUSBRedirection.enable = true;
 
-  environment.systemPackages = with pkgs; [
-    # Ensure existing qemu-img with lima for use of systemd.
-    # Because of lima might be started with systemd, and then the Nix wrapped qemu PATH will be ignored.
-    # See GH-1049 for details.
-    qemu
+  environment.systemPackages =
+    with pkgs;
+    [
+      # Ensure existing qemu-img with lima for use of systemd.
+      # Because of lima might be started with systemd, and then the Nix wrapped qemu PATH will be ignored.
+      # See GH-1049 for details.
+      qemu
 
-    # Use latest to apply latest osinfo-db such as https://github.com/nixos/nixpkgs/pull/414620
-    # It is the actual OS information for the VM, upstream is https://gitlab.com/libosinfo/osinfo-db
-    unstable.gnome-boxes
-
-    # Best experience when considering clipboard behaviors. See GH-1310 for details
-    unstable.winboat
-  ];
+      # Use latest to apply latest osinfo-db such as https://github.com/nixos/nixpkgs/pull/414620
+      # It is the actual OS information for the VM, upstream is https://gitlab.com/libosinfo/osinfo-db
+      unstable.gnome-boxes
+    ]
+    ++ lib.optional (!config.profiles.recovery) unstable.winboat;
 }

--- a/nixos/hosts/installer/default.nix
+++ b/nixos/hosts/installer/default.nix
@@ -10,17 +10,19 @@ let
   mkUser = import ../../desktop/mkUser.nix { inherit lib; };
 in
 {
+  # Strictly follow the "Nix Flakes" section of the Wiki
   imports = [
-    # Strictly follow the "Nix Flakes" section of the Wiki
     (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
 
     # Project specific desktop tools/settings
     outputs.nixosModules.desktop
+    outputs.nixosModules.options
   ];
+
+  profiles.recovery = true;
 
   # Wiki "Building faster" section
   isoImage.squashfsCompression = "gzip -Xcompression-level 1";
-
   # Wiki "SSH" section: Enable SSH and set keys for root
   systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
   users.users.root.openssh.authorizedKeys.keys = import ../../../config/ssh/keys.nix;

--- a/nixos/modules/default.nix
+++ b/nixos/modules/default.nix
@@ -7,4 +7,5 @@
   ephemeral = ../desktop/ephemeral.nix;
   home-manager = inputs.home-manager-linux.nixosModules.home-manager;
   cloudflare-warp = ./cloudflare-warp.nix;
+  options = ./options.nix;
 }

--- a/nixos/modules/desktop.nix
+++ b/nixos/modules/desktop.nix
@@ -3,6 +3,7 @@
   imports = [
     ../configuration.nix
     outputs.nixosModules.home-manager
+    outputs.nixosModules.options
     ../desktop
   ];
 

--- a/nixos/modules/options.nix
+++ b/nixos/modules/options.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+{
+  options.profiles.recovery = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Whether to enable the recovery profile.
+      When enabled, non-essential large packages and fonts are excluded to reduce ISO/disk size.
+    '';
+  };
+}


### PR DESCRIPTION
This profile aims to reduce the NixOS Live ISO size by excluding large
GUI applications, npm-based language servers, games, and optional
fonts that are not required for system recovery or maintenance.

- Add profiles.recovery option in nixos/modules/options.nix
- Exclude rhythmbox, newsflash, readest, podman-desktop, papers,
  signal-desktop, winboat, and vscode-langservers-extracted
- Replace Source Han family with noto-fonts-cjk-sans for lightweight
  Japanese support
- Sync Home Manager settings (favorite-apps, mimeApps) with the
  recovery profile
