### PR TITLE
Bump go to 1.27

### DIFF
--- a/cmd/wsl-init/main.go
+++ b/cmd/wsl-init/main.go
@@ -65,13 +65,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("cannot get uname: %+v\n", err)
 	}
-	unameStr := ""
+	var unameStr strings.Builder
 	// So here, using uname, as I understand it is same as `uname -r`
 	for _, i8 := range uname.Release {
-		unameStr += string(rune(int(i8)))
+		unameStr.WriteString(string(rune(int(i8))))
 	}
-	if !strings.Contains(unameStr, "microsoft-standard-WSL2") {
-		log.Fatalf("Looks executed on non WSL systems: %s", unameStr)
+	if !strings.Contains(unameStr.String(), "microsoft-standard-WSL2") {
+		log.Fatalf("Looks executed on non WSL systems: %s", unameStr.String())
 	}
 
 	mustActivateSystemdOnWSL()

--- a/devShells.nix
+++ b/devShells.nix
@@ -48,7 +48,7 @@ in
           dprint
           zizmor
           rumdl
-          go_1_26
+          go_1_27
         ])
         ++ (with pkgs.local; [
           nix-hash-url

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,19 @@
 module github.com/kachick/dotfiles
 
-go 1.26.7
+go 1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0
+	github.com/mattn/go-pipeline v0.0.0-20190323144519-32d779b32768
+	github.com/mattn/go-runewidth v0.0.28
 	github.com/yusufpapurcu/wmi v1.2.4
 	golang.org/x/sys v0.47.0
 )
 
-require github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
-
 require (
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 // indirect
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/mattn/go-pipeline v0.0.0-20190323144519-32d779b32768
-	github.com/mattn/go-runewidth v0.0.28
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect

--- a/home-manager/helix-lsp.nix
+++ b/home-manager/helix-lsp.nix
@@ -183,7 +183,7 @@ in
       rust-analyzer
 
       # Looks like required to enable gopls
-      unstable.go_1_26
+      unstable.go_1_27
       # https://github.com/helix-editor/helix/blob/24.03/languages.toml#L578
       unstable.gopls
       # https://github.com/helix-editor/helix/blob/24.03/languages.toml#L132-L133

--- a/home-manager/telemetry.nix
+++ b/home-manager/telemetry.nix
@@ -16,7 +16,7 @@
       # go generally put on .config/go/telemetry, however using the cmd is the recommended way
       # ref: https://go.dev/doc/telemetry
       disableGoTelemetry = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-        ${lib.getExe pkgs.unstable.go_1_26} telemetry off
+        ${lib.getExe pkgs.unstable.go_1_27} telemetry off
       '';
 
       # GH-1228: Disable podman-desktop Telemetry.

--- a/pkgs/by-name/ar/archive-home-files/package.nix
+++ b/pkgs/by-name/ar/archive-home-files/package.nix
@@ -7,11 +7,11 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
   keys = import ../../../../config/ssh/keys.nix;
   betterleaksConfig = ../../../../config/betterleaks/.betterleaks.toml;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "archive-home-files";
   version = "0.1.0";
 

--- a/pkgs/by-name/bu/bump_gomod/package.nix
+++ b/pkgs/by-name/bu/bump_gomod/package.nix
@@ -4,7 +4,7 @@ pkgs.writeShellApplication rec {
   text = builtins.readFile ./${name}.bash;
   runtimeInputs = with pkgs; [
     gitMinimal
-    unstable.go_1_26
+    unstable.go_1_27
     gnugrep
     findutils # `xargs`
     nix-update

--- a/pkgs/by-name/co/conoha-cli/package.nix
+++ b/pkgs/by-name/co/conoha-cli/package.nix
@@ -10,9 +10,9 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "conoha-cli";
   version = "0.8.0";
 

--- a/pkgs/by-name/gi/git-hooks-pre-push/package.nix
+++ b/pkgs/by-name/gi/git-hooks-pre-push/package.nix
@@ -6,9 +6,9 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "git-hooks-pre-push";
   version = "0.0.1";
 

--- a/pkgs/by-name/ib/ibus-engine-selector/package.nix
+++ b/pkgs/by-name/ib/ibus-engine-selector/package.nix
@@ -9,9 +9,9 @@
 
 let
   configPath = ../../../../config/mozc/ibus_config.textproto;
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "ibus-engine-selector";
   version = "0.1.0";
 

--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -4,10 +4,10 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module; # Keep same toolset as lima package
+  inherit (pkgs.unstable) buildGo127Module; # Keep same toolset as lima package
   inherit (pkgs.local) lima;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "lima-additional-guestagents";
 
   inherit (lima) version src vendorHash;

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -20,10 +20,10 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
   inherit (pkgs.local) lima;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "lima";
   version = "2.2.0";
 

--- a/pkgs/by-name/ni/nix-diff/package.nix
+++ b/pkgs/by-name/ni/nix-diff/package.nix
@@ -6,9 +6,9 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "nix-diff";
   version = "0.0.1";
 

--- a/pkgs/by-name/re/reponame/main.go
+++ b/pkgs/by-name/re/reponame/main.go
@@ -13,8 +13,7 @@ func extractRepo(line string) string {
 	base := strings.TrimPrefix(line, "git@github.com:")
 	base = strings.TrimPrefix(base, "https://github.com/")
 	base = strings.TrimSuffix(base, ".git")
-	// Using Cut cannot handle `multiple sep as foo/bar/baz`, but I don't need to conisder it for `owner/repo` or `repo` patterns.
-	_, after, found := strings.Cut(base, "/")
+	_, after, found := strings.CutLast(base, "/")
 	if found {
 		return after
 	} else {

--- a/pkgs/by-name/re/reponame/main_test.go
+++ b/pkgs/by-name/re/reponame/main_test.go
@@ -17,6 +17,10 @@ func TestExtractRepo(t *testing.T) {
 			input: "kachick/dotfiles",
 			repo:  "dotfiles",
 		},
+		"nested/owner/repo": {
+			input: "gitlab.com/group/subgroup/repo",
+			repo:  "repo",
+		},
 		"repo": {
 			input: "dotfiles",
 			repo:  "dotfiles",

--- a/pkgs/by-name/re/reponame/package.nix
+++ b/pkgs/by-name/re/reponame/package.nix
@@ -5,9 +5,9 @@
 }:
 
 let
-  inherit (pkgs.unstable) buildGo126Module;
+  inherit (pkgs.unstable) buildGo127Module;
 in
-buildGo126Module (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "reponame";
   version = "0.0.1";
 


### PR DESCRIPTION
- **Bump go 1.26 to 1.27**
- **Adopt Go 1.27 updates and features**

https://go.dev/doc/go1.27
