### PR TITLE
Include detailed nix-diff in package diff reports

### DIFF
--- a/pkgs/by-name/ni/nix-diff/main.go
+++ b/pkgs/by-name/ni/nix-diff/main.go
@@ -71,9 +71,7 @@ func main() {
 
 		if diff != "" {
 			fmt.Printf("<details open><summary><b>%s</b></summary>\n\n", target.Name)
-			fmt.Println("```text")
 			fmt.Print(diff)
-			fmt.Println("```")
 			fmt.Println("</details>")
 			fmt.Println("")
 			hasDiff = true
@@ -100,17 +98,74 @@ func compareTarget(base, current string, target Target) (string, error) {
 		return "", nil
 	}
 
-	// Use dix to diff the derivations.
-	// Dix is guaranteed to be in PATH by the nix packaging (wrapProgram).
-	cmd := exec.Command("dix", oldDrv, newDrv)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("dix failed: %w", err)
+	dixOut, dixErr := runDix(oldDrv, newDrv)
+	nixDiffOut, nixDiffErr := runNixDiff(oldDrv, newDrv)
+
+	if dixErr != nil && nixDiffErr != nil {
+		return "", fmt.Errorf("both dix and nix-diff failed (dix: %v, nix-diff: %v)", dixErr, nixDiffErr)
 	}
 
+	return formatReport(dixOut, nixDiffOut, dixErr, nixDiffErr), nil
+}
+
+func runDix(oldDrv, newDrv string) (string, error) {
+	cmd := exec.Command("dix", oldDrv, newDrv)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("dix failed: %w: %s", err, strings.TrimSpace(errOut.String()))
+	}
 	return out.String(), nil
+}
+
+func runNixDiff(oldDrv, newDrv string) (string, error) {
+	cmd := exec.Command("nix-diff", "--color", "never", oldDrv, newDrv)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("nix-diff failed: %w: %s", err, strings.TrimSpace(errOut.String()))
+	}
+	return out.String(), nil
+}
+
+func formatReport(dixOut, nixDiffOut string, dixErr, nixDiffErr error) string {
+	var buf strings.Builder
+	buf.WriteString("### Package Version Changes (dix)\n\n")
+	if dixErr != nil {
+		buf.WriteString("```text\n")
+		buf.WriteString(dixErr.Error())
+		buf.WriteString("\n```\n\n")
+	} else if strings.TrimSpace(dixOut) != "" {
+		buf.WriteString("```text\n")
+		buf.WriteString(dixOut)
+		if !strings.HasSuffix(dixOut, "\n") {
+			buf.WriteString("\n")
+		}
+		buf.WriteString("```\n\n")
+	} else {
+		buf.WriteString("No version changes detected.\n\n")
+	}
+
+	buf.WriteString("<details><summary>Detailed Derivation Diff (nix-diff)</summary>\n\n")
+	if nixDiffErr != nil {
+		buf.WriteString("```text\n")
+		buf.WriteString(nixDiffErr.Error())
+		buf.WriteString("\n```\n")
+	} else if strings.TrimSpace(nixDiffOut) != "" {
+		buf.WriteString("```text\n")
+		buf.WriteString(nixDiffOut)
+		if !strings.HasSuffix(nixDiffOut, "\n") {
+			buf.WriteString("\n")
+		}
+		buf.WriteString("```\n")
+	} else {
+		buf.WriteString("No derivation changes detected.\n")
+	}
+	buf.WriteString("</details>\n")
+
+	return buf.String()
 }
 
 func getDerivation(flakePath string) (string, error) {

--- a/pkgs/by-name/ni/nix-diff/main_test.go
+++ b/pkgs/by-name/ni/nix-diff/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFormatReport(t *testing.T) {
+	tests := []struct {
+		name       string
+		dixOut     string
+		nixDiffOut string
+		dixErr     error
+		nixDiffErr error
+		wantSub    []string
+	}{
+		{
+			name:       "both have output",
+			dixOut:     "CHANGED\n[U.] foo 1.0 -> 1.1\n",
+			nixDiffOut: "• foo differs\n",
+			dixErr:     nil,
+			nixDiffErr: nil,
+			wantSub: []string{
+				"### Package Version Changes (dix)",
+				"[U.] foo 1.0 -> 1.1",
+				"<details><summary>Detailed Derivation Diff (nix-diff)</summary>",
+				"• foo differs",
+			},
+		},
+		{
+			name:       "dix empty but nix-diff has changes",
+			dixOut:     "",
+			nixDiffOut: "• typescript-go differs\n",
+			dixErr:     nil,
+			nixDiffErr: nil,
+			wantSub: []string{
+				"### Package Version Changes (dix)",
+				"No version changes detected.",
+				"<details><summary>Detailed Derivation Diff (nix-diff)</summary>",
+				"• typescript-go differs",
+			},
+		},
+		{
+			name:       "dix error but nix-diff succeeds",
+			dixOut:     "",
+			nixDiffOut: "• bar differs\n",
+			dixErr:     errors.New("dix: broken drv"),
+			nixDiffErr: nil,
+			wantSub: []string{
+				"### Package Version Changes (dix)",
+				"dix: broken drv",
+				"<details><summary>Detailed Derivation Diff (nix-diff)</summary>",
+				"• bar differs",
+			},
+		},
+		{
+			name:       "both empty",
+			dixOut:     "",
+			nixDiffOut: "",
+			dixErr:     nil,
+			nixDiffErr: nil,
+			wantSub: []string{
+				"### Package Version Changes (dix)",
+				"No version changes detected.",
+				"<details><summary>Detailed Derivation Diff (nix-diff)</summary>",
+				"No derivation changes detected.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatReport(tt.dixOut, tt.nixDiffOut, tt.dixErr, tt.nixDiffErr)
+			for _, sub := range tt.wantSub {
+				if !strings.Contains(got, sub) {
+					t.Errorf("formatReport() missing expected substring %q in:\n%s", sub, got)
+				}
+			}
+		})
+	}
+}

--- a/pkgs/by-name/ni/nix-diff/package.nix
+++ b/pkgs/by-name/ni/nix-diff/package.nix
@@ -32,7 +32,12 @@ buildGo127Module (finalAttrs: {
 
   postInstall = ''
     wrapProgram $out/bin/nix-diff \
-      --prefix PATH : ${lib.makeBinPath [ unstable.dix ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          unstable.dix
+          unstable.nix-diff
+        ]
+      }
   '';
 
   env.CGO_ENABLED = 0;


### PR DESCRIPTION
For reviewing https://github.com/kachick/dotfiles/pull/1666, I colundn't know the PR including typescript-go changes if it does not change the version number:
https://github.com/NixOS/nixpkgs/commit/5bf662c854c6178cd8131fb83b6021b809291b88

Dix reports high-level package version changes, but it omits packages
when the version string is unchanged (such as rebuilds due to compiler
flag changes, bundled assets, or patch revisions).

Run both dix and nix-diff to produce a hybrid report: the concise
version changes from dix remain at the top, while detailed derivation
diffs from nix-diff are folded inside a details block.
